### PR TITLE
Fix build jar for airlift build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 4
+
+* [BUGFIX] build-airlift profile puts main class and classpath into the main jar.
+
 Airbase 3
 
 * Fork mode can be configured with air.test.fork-mode.

--- a/pom.xml
+++ b/pom.xml
@@ -1177,6 +1177,19 @@
                     </plugin>
 
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>${main-class}</mainClass>
+                                    <addClasspath>true</addClasspath>
+                                    <useUniqueVersions>false</useUniqueVersions>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
                         <executions>


### PR DESCRIPTION
The main jar for the airlift build must contain the main class and classpath
attributes, otherwise an airlift built tarball will not start from the launcher.
