### PR TITLE
Update maven dependency plugin version to 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8</version>
                     <configuration>
                         <skip>${air.check.skip-dependency}</skip>
                         <failOnWarning>${air.check.fail-dependency}</failOnWarning>


### PR DESCRIPTION
mvn dependency:tree is broken in maven 3.1+ with the 2.7 plugin
