### PR TITLE
Add io.airlift:slice:0.5 to dependency management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ Airbase provides versions for the following well-known dependencies:
     <td>Hamcrest matchers</td>
     <td><tt>org.hamcrest:hamcrest-core</tt><p/><tt>org.hamcrest:hamcrest-library</tt><p/><tt>org.objenesis:objenesis</tt></td>
   </tr>
+  <tr>
+    <td>Airlift Slice</td>
+    <td><tt>io.airlift:slice</tt></td>
+  </tr>
 </table>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <dep.hamcrest.version>1.3</dep.hamcrest.version>
         <dep.mockito.version>1.9.5</dep.mockito.version>
         <dep.objenesis.version>1.3</dep.objenesis.version>
+        <dep.slice.version>0.5</dep.slice.version>
 
         <!-- license headers -->
         <air.license.owner>${project.organization.name}</air.license.owner>
@@ -1146,6 +1147,12 @@
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>${dep.objenesis.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>slice</artifactId>
+                <version>${dep.slice.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The version can be overridden via the dep.slice.version property
