### PR TITLE
Ignore conflicting THIRD-PARTY in resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,7 @@
                             <ignoredResource>about_files/.*</ignoredResource>
                             <ignoredResource>plugin\.properties</ignoredResource>
                             <ignoredResource>.*\.java</ignoredResource>
+                            <ignoredResource>THIRD-PARTY</ignoredResource>
                         </ignoredResources>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Some libraries such as jmh have multiple artifacts with this file in them.
