### PR TITLE
Add M2Eclipse configuration for Jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,23 @@
                                         <ignore />
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                  <pluginExecutionFilter>
+                                    <groupId>org.jacoco</groupId>
+                                    <artifactId>
+                                      jacoco-maven-plugin
+                                    </artifactId>
+                                    <versionRange>
+                                      [0.6.2.201302030002,)
+                                    </versionRange>
+                                    <goals>
+                                      <goal>prepare-agent</goal>
+                                    </goals>
+                                  </pluginExecutionFilter>
+                                  <action>
+                                    <ignore></ignore>
+                                  </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
We currently do not integrate with Jacoco in the Eclipse so we want to
ignore any warnings about Jacoco.
