### PR TITLE
capture git versioning information in manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,25 @@
                                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 <addClasspath>false</addClasspath>
                             </manifest>
+                            <manifestEntries>
+                                <!-- This is actually the time when the build was done -->
+                                <Build-Time>${git.build.time}</Build-Time>
+                                <Git-Commit-Id>${git.commit.id}</Git-Commit-Id>
+                                <Implementation-Version>${git.commit.id.describe}</Implementation-Version>
+                            </manifestEntries>
                         </archive>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>2.1.13</version>
+                    <configuration>
+                        <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
+                        <gitDescribe>
+                            <tags>true</tags>
+                        </gitDescribe>
                     </configuration>
                 </plugin>
 
@@ -883,6 +901,20 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
For every generated jar, capture git versioning information in Java manifest.
This allows to tell at runtime exact git commit id that this jar was built from.