### PR TITLE
Update to Jetty 9.2.11.v20150529

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 40
+
+* Dependency updates:
+  - Jetty 9.2.11.v20150529 (from Jetty 9.2.11.M0)
+
 Airbase 39
 
 * Dependency updates:

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dep.apache-bval.version>0.5</dep.apache-bval.version>
         <dep.jackson.version>2.4.4</dep.jackson.version>
         <dep.jersey.version>2.12</dep.jersey.version>
-        <dep.jetty.version>9.2.11.M0</dep.jetty.version>
+        <dep.jetty.version>9.2.11.v20150529</dep.jetty.version>
         <dep.jmxutils.version>1.18</dep.jmxutils.version>
         <dep.cglib.version>2.2.2</dep.cglib.version>
         <dep.joda.version>2.8</dep.joda.version>


### PR DESCRIPTION
It fixes a race condition that can cause requests to hang