### PR TITLE
Update to joda-time 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <dep.jetty.version>9.2.11.v20150529</dep.jetty.version>
         <dep.jmxutils.version>1.18</dep.jmxutils.version>
         <dep.cglib.version>2.2.2</dep.cglib.version>
-        <dep.joda.version>2.8</dep.joda.version>
+        <dep.joda.version>2.8.2</dep.joda.version>
         <dep.findbugs-annotations.version>2.0.3</dep.findbugs-annotations.version>
         <dep.testng.version>6.8.7</dep.testng.version>
         <dep.hamcrest.version>1.3</dep.hamcrest.version>


### PR DESCRIPTION
Per https://stackoverflow.com/questions/32058431/aws-java-sdk-aws-authentication-requires-a-valid-date-or-x-amz-date-header joda-time < 2.8.1 is broken on 8u60 which breaks aws connectivity in presto. Per http://www.joda.org/joda-time/upgradeto282.html the only other change is newer DateTimeZone data.