### PR TITLE
testng - exclude guice dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 46
+
+* Dependency updates:
+    - TestNG, exclude transitive guice dependency
+
 Airbase 45
 
 * Dependency updates:

--- a/pom.xml
+++ b/pom.xml
@@ -1284,6 +1284,10 @@
                         <groupId>junit</groupId>
                         <artifactId>junit</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
testng - exclude guice dependency

testng@6.9.6 is depending on guice@4.0-no_aop. It is common that this
dependency (guice) is conflicting as many projects is using guice with
AOP support.
