### PR TITLE
Upgrade jackson to 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,8 @@
         <dep.javax-validation.version>1.1.0.Final</dep.javax-validation.version>
         <dep.javax-servlet.version>3.1.0</dep.javax-servlet.version>
         <dep.apache-bval.version>0.5</dep.apache-bval.version>
-        <dep.jackson.version>2.4.4</dep.jackson.version>
+        <dep.jackson.version>2.7.1</dep.jackson.version>
+        <dep.jackson.datatype.jdk7.version>2.6.6</dep.jackson.datatype.jdk7.version>
         <dep.jersey.version>2.22.2</dep.jersey.version>
         <dep.jetty.version>9.3.9.M1</dep.jetty.version>
         <dep.jmxutils.version>1.19</dep.jmxutils.version>
@@ -1144,7 +1145,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk7</artifactId>
-                <version>${dep.jackson.version}</version>
+                <version>${dep.jackson.datatype.jdk7.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I'd like to propose an upgrade of the Jackson dependencies to 2.7.1.