### PR TITLE
Update dependency-versions-check to 2.0.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 58
+
+* Plugin updates:
+  - dependency-versions-check 2.0.4 (from 2.0.2)
+
 Airbase 57
 
 * Remove dependency for jackson-datatype-jdk7

--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
                 <plugin>
                     <groupId>com.ning.maven.plugins</groupId>
                     <artifactId>maven-dependency-versions-check-plugin</artifactId>
-                    <version>2.0.2</version>
+                    <version>2.0.4</version>
                     <configuration>
                         <skip>${air.check.skip-dependency-version-check}</skip>
                         <failBuildInCaseOfConflict>${air.check.fail-dependency-version-check}</failBuildInCaseOfConflict>


### PR DESCRIPTION
This version resolves dependencies in parallel and is much faster.