### PR TITLE
Upgrade JMH to 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <dep.mockito.version>1.9.5</dep.mockito.version>
         <dep.objenesis.version>1.3</dep.objenesis.version>
         <dep.slice.version>0.10</dep.slice.version>
-        <dep.jmh.version>1.13</dep.jmh.version>
+        <dep.jmh.version>1.15</dep.jmh.version>
 
         <!-- license headers -->
         <air.license.owner>${project.organization.name}</air.license.owner>


### PR DESCRIPTION
It'd be nice to use the latest version as of today.

ref. http://mail.openjdk.java.net/pipermail/jmh-dev/2016-September/002371.html