### PR TITLE
Remove air.test.fork-mode property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Airbase 59
 
+* Remove air.test.fork-mode property
 * Dependency updates:
   - JMH 1.15 (from 1.13)
 * Plugin updates:

--- a/README.md
+++ b/README.md
@@ -439,9 +439,6 @@ For a multi-module project, all other sub-modules must have this explicitly set 
 
 must be added to each pom. This is a limitation of the Maven multi-module build process (see http://stackoverflow.com/questions/1012402/maven2-property-that-indicates-the-parent-directory for details).
 
-### air.test.fork-mode
-
-Defines the fork mode for running tests. Default is 'once' which is forking one JVM for all tests. Valid values are the same as for the maven-surefire-plugin (once, always, never).
 
 
 ## Deploy profiles

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,6 @@
         <!-- the upstream repository. Default is no. -->
         <air.release.push-changes>false</air.release.push-changes>
 
-        <!-- define the forkmode for tests. Default is 'once' -->
-        <air.test.fork-mode>once</air.test.fork-mode>
-
         <!-- define the thread count for parallel tests. -->
         <air.test.thread-count>1</air.test.thread-count>
 
@@ -458,7 +455,6 @@
                             <java.awt.headless>true</java.awt.headless>
                             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
                         </systemPropertyVariables>
-                        <forkMode>${air.test.fork-mode}</forkMode>
                         <runOrder>random</runOrder>
                         <parallel>${air.test.parallel}</parallel>
                         <threadCount>${air.test.thread-count}</threadCount>


### PR DESCRIPTION
The forkMode parameter is deprecated in Surefire.