### PR TITLE
Forbid import of format methods other than String.format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 80
+
+* Checkstyle updates:
+  - Forbid import of format methods other than String.format
+
 Airbase 79
 
 * Use Apache license header from policy JAR

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -49,6 +49,10 @@
         <property name="format" value="^import static .*\.(of|copyOf|valueOf);$" />
         <property name="message" value="The following methods may not be statically imported: of, copyOf, valueOf" />
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static (?!java\.lang\.String\.format;).*\.format;" />
+        <property name="message" value="Only 'format' from java.lang.String may be statically imported" />
+    </module>
 
     <module name="RegexpSingleline">
         <property name="format" value="^([^i]|i[^m]|im[^p]|imp[^o]|impo[^r]|impor[^t]|import[^ ]).*Objects\.requireNonNull" />


### PR DESCRIPTION
This is to prevent cases like https://github.com/prestodb/presto/pull/9807