### PR TITLE
Require release dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 84
+
+* Forbid snapshot versions for dependencies
+
 Airbase 83
 
 * Dependency updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -307,6 +307,13 @@
                             <requireJavaVersion>
                                 <version>${air.java.version}</version>
                             </requireJavaVersion>
+                            <requireReleaseDeps>
+                                <message>Snapshot dependencies are not allowed</message>
+                                <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                <excludes>
+                                    <exclude>${project.groupId}:*</exclude>
+                                </excludes>
+                            </requireReleaseDeps>
                         </rules>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Add maven-enforcer-plugin rule that checks the dependencies
and fails if any snapshots are found.