### PR TITLE
Do not allow duplicate dependencies in POMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - openjdk10
   - openjdk11
   - openjdk-ea

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 85
+
+* Do not allow duplicate dependencies in POMs
+
 Airbase 84
 
 * Do not trim stack traces for Surefire test failures

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -301,6 +301,7 @@
                                     <include>junit:junit:[4.11,)</include>
                                 </includes>
                             </bannedDependencies>
+                            <banDuplicatePomDependencyVersions />
                             <requireMavenVersion>
                                 <version>${air.maven.version}</version>
                             </requireMavenVersion>


### PR DESCRIPTION
Example failure:
```
$ mvn validate
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.airlift:slice:jar:0.37-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.openjdk.jol:jol-core:jar -> duplicate declaration of version 0.2 @ line 45, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] --------------------------< io.airlift:slice >--------------------------
[INFO] Building slice 0.37-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (default) @ slice ---
[WARNING] Rule 1: org.apache.maven.plugins.enforcer.BanDuplicatePomDependencyVersions failed with message:
Found 1 duplicate dependency declaration in this project:
 - dependencies.dependency[org.openjdk.jol:jol-core:jar] ( 2 times )

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.162 s
[INFO] Finished at: 2018-10-22T14:55:26-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (default) on project slice: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```