### PR TITLE
Do not enforce whitespace before array initializers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 86
+
+* Checkstyle updates:
+  - Do not enforce whitespace before array initializers
+
 Airbase 85
 
 * Do not allow duplicate dependencies in POMs

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -183,7 +183,7 @@
             <property name="allowEmptyLambdas" value="true" />
             <property name="ignoreEnhancedForColon" value="false" />
             <property name="tokens" value="
-                ARRAY_INIT, ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN,
+                ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN,
                 BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAND,
                 LAMBDA, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
                 LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH,


### PR DESCRIPTION
This check does not work as expected for multidimensional arrays.