### PR TITLE
Generate parameters names reliably

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 87
+
+* Generate parameters names also when compiling in IntelliJ
+
 Airbase 86
 
 * Checkstyle updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -346,7 +346,10 @@
                         <maxmem>${air.build.jvmsize}</maxmem>
                         <showWarnings>true</showWarnings>
                         <fork>true</fork>
-                        <parameters>true</parameters>
+                        <compilerArgs>
+                            <!-- Revert to <parameters>true</parameters> once IntelliJ 183.888 is widespread -->
+                            <arg>-parameters</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Due to https://youtrack.jetbrains.com/issue/IDEA-194601, when using
```
<artifactId>maven-compiler-plugin</artifactId>
<configuration>
    <parameters>true</parameters>
...
```

parameters are not generated when code is compiled in IntelliJ.

Also, manual IDE configuration is not an option, since the configuration
gets reset each time IDE auto-loads pom changes.