### PR TITLE
Update maven-source-plugin to 3.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 91
 
 * Dependency updates:
   - Jackson 2.9.8 (from 2.9.7)
+* Plugin updates:
+  - Sources 3.0.1 (from 2.2.1)
 
 Airbase 90
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -526,7 +526,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>


### PR DESCRIPTION
This fixes skipping sources with `-Dmaven.source.skip=true`. The flag is
said documented as supported "since 2.2", but was not effective in 2.2.1.