### PR TITLE
Bump Jackson to 2.9.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 92
+
+* Dependency updates:
+  - Jackson 2.9.10 (from 2.9.8)
+
 Airbase 91
 
 * Require package names not to contain uppercase letters nor underscores.

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -181,7 +181,7 @@
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
         <dep.javax-servlet.version>3.1.0</dep.javax-servlet.version>
         <dep.bval.version>2.0.0</dep.bval.version>
-        <dep.jackson.version>2.9.8</dep.jackson.version>
+        <dep.jackson.version>2.9.10</dep.jackson.version>
         <dep.jmxutils.version>1.19</dep.jmxutils.version>
         <dep.cglib.version>3.2.5</dep.cglib.version>
         <dep.joda.version>2.9.9</dep.joda.version>


### PR DESCRIPTION
Dear maintainers. 

I'd like to bump Jackson to 2.9.9 and databind to 2.9.9.3 due to discovered CVE's in databind: https://www.cvedetails.com/vulnerability-list.php?vendor_id=15866&product_id=42991&version_id=&page=1&hasexp=0&opdos=0&opec=0&opov=0&opcsrf=0&opgpriv=0&opsqli=0&opxss=0&opdirt=0&opmemc=0&ophttprs=0&opbyp=0&opfileinc=0&opginf=0&cvssscoremin=0&cvssscoremax=0&year=0&month=0&cweid=0&order=1&trc=23&sha=5425c8855ccdf6005f8b83f6d90fed738cf8a8e8

This triggered my vulnerability scanner, and it would be great to get this patched. Bumping to 2.10 isn't possible yet since we're supporting Java8. Would it be possible to create a new release as well? So I can downstream this in other projects. Please let me know.

Cheers, Fokko