### PR TITLE
Replace Oracle Java 8 with OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - oraclejdk9
   - openjdk10
   - openjdk11


### PR DESCRIPTION
Oracle Java 8 is no longer available on Travis.