### PR TITLE
Make the CI happy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: java
 
 jdk:
   - openjdk8
-  - oraclejdk9
+  - openjdk9
   - openjdk10
   - openjdk11
   - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea


### PR DESCRIPTION
Hi all,

I'd like to propose the following changes:
- Move from Oracle to OpenJDK completely. Something is off with the Oracle builders of Travis: https://travis-ci.org/airlift/airbase/jobs/592909648
- Set JDK14 Early Access to allow failure. This will run the build but ignore the result. Therefore the badge on the repository will be green, looking all good won't upset any users. The current issue that we're seeing is spotted by Gradle and Groovy as well and seems to be something with the JDK: https://github.com/gradle/gradle/issues/10248

Cheers, Fokko