### PR TITLE
Updated git commit id plugin

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -513,7 +513,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.1.13</version>
+                    <version>3.0.1</version>
                     <configuration>
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
                         <gitDescribe>


### PR DESCRIPTION
- to version 3.0.1
- requires Java 8 and Maven 3.3.9+
- allows skipping with -Dmaven.gitcommitid.skip=true
- results in faster build since remote git fetch is avoided
- see https://github.com/git-commit-id/maven-git-commit-id-plugin/blob/master/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java#L241
- https://github.com/git-commit-id/maven-git-commit-id-plugin

Signed-off-by: Manfred Moser <mmoser@apache.org>
Signed-off-by: Manfred Moser <manfred@simpligility.com>