### PR TITLE
Remove dependency:analyze-dep-mgt check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 96
+
+* Remove dependency:analyze-dep-mgt check
+
 Airbase 95
 
 * Dependency updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -359,7 +359,6 @@
                             <goals>
                                 <goal>analyze-only</goal>
                                 <goal>analyze-duplicate</goal>
-                                <goal>analyze-dep-mgt</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
The primary motivation for this checker seems to have been long since
fixed in Maven, and the other warnings it provides are not useful.