### PR TITLE
Parameterize distributionManagement

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -65,14 +65,14 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>${air.snapshot.repository.id}</id>
+            <name>${air.snapshot.repository.name}</name>
+            <url>${air.snapshot.repository.url}</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>${air.release.repository.id}</id>
+            <name>${air.release.repository.name}</name>
+            <url>${air.release.repository.url}</url>
         </repository>
     </distributionManagement>
 
@@ -203,6 +203,14 @@
         <!-- Readme for launcher -->
         <air.readme.file>README.txt</air.readme.file>
         <air.readme.type>txt</air.readme.type>
+
+        <!-- Properties for controlling distributionManagement -->
+        <air.snapshot.repository.id>ossrh</air.snapshot.repository.id>
+        <air.snapshot.repository.name>Sonatype Nexus Snapshots</air.snapshot.repository.name>
+        <air.snapshot.repository.url>https://oss.sonatype.org/content/repositories/snapshots</air.snapshot.repository.url>
+        <air.release.repository.id>ossrh</air.release.repository.id>
+        <air.release.repository.name>Sonatype Release Snapshots</air.release.repository.name>
+        <air.release.repository.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</air.release.repository.url>
     </properties>
 
     <build>


### PR DESCRIPTION
There are cases where users of your project want to deploy snapshots (or releases) of your project to their Maven repositories for integration testing or for patch releases. You would setup something like the following:

<project>
    <properties>
        <!-- Distribution Management Properties -->                                                                                                       
        <air.snapshot.repository.id>ossrh</air.snapshot.repository.id>                                                                              
        <air.snapshot.repository.name>Sonatype Nexus Snapshots</air.snapshot.repository.name>                                                      
        <air.snapshot.repository.url>https://oss.sonatype.org/content/repositories/snapshots</air.snapshot.repository.url>                          
        <air.release.repository.id>ossrh</air.release.repository.id>                                                                                
        <air.release.repository.name>Sonatype Release Snapshots</air.release.repository.name>                                                       
        <presto.release.repository.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</presto.release.repository.url>                      
    </properties>       

    <distributionManagement>                                                                                                                              
        <snapshotRepository>                                                                                                                              
            <id>${air.snapshot.repository.id}</id>                                                                                                     
            <name>${air.snapshot.repository.name}</name>                                                                                               
            <url>${air.snapshot.repository.url}</url>                                                                                                  
        </snapshotRepository>                                                                                                                             
        <repository>                                                                                                                                      
            <id>${air.release.repository.id}</id>                                                                                                      
            <name>${air.release.repository.name}</name>                                                                                                
            <url>${air.release.repository.url}</url>                                                                                                   
        </repository>                                                                                                                                     
    </distributionManagement>     
</project>

Then users can set a profile themselves overriding these properties to direct the deployment to the desired location.