### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Airbase 99
 * Dependency updates:
   - Slf4j 1.7.30 (from 1.7.29)
   - Jackson 2.10.3 (from 2.10.0)
+  - Guice 4.2.3 (from 4.2.2)
 
 Airbase 98
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Airbase 99
 
 * Dependency updates:
   - Slf4j 1.7.30 (from 1.7.29)
+  - Jackson 2.10.3 (from 2.10.0)
 
 Airbase 98
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 99
+
+* Dependency updates:
+  - Slf4j 1.7.30 (from 1.7.29)
+
 Airbase 98
 
 * Parameterize distributionManagement

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -175,7 +175,7 @@
         <!-- Dependency versions that should be the same everywhere. -->
         <dep.guice.version>4.2.2</dep.guice.version>
         <dep.guava.version>26.0-jre</dep.guava.version>
-        <dep.slf4j.version>1.7.29</dep.slf4j.version>
+        <dep.slf4j.version>1.7.30</dep.slf4j.version>
         <dep.logback.version>1.2.3</dep.logback.version>
         <dep.javax-inject.version>1</dep.javax-inject.version>
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -181,7 +181,7 @@
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
         <dep.javax-servlet.version>4.0.1</dep.javax-servlet.version>
         <dep.bval.version>2.0.0</dep.bval.version>
-        <dep.jackson.version>2.10.0</dep.jackson.version>
+        <dep.jackson.version>2.10.3</dep.jackson.version>
         <dep.jmxutils.version>1.21</dep.jmxutils.version>
         <dep.cglib.version>3.3.0</dep.cglib.version>
         <dep.joda.version>2.10.5</dep.joda.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -173,7 +173,7 @@
         <dep.packaging.version>0.163</dep.packaging.version>
 
         <!-- Dependency versions that should be the same everywhere. -->
-        <dep.guice.version>4.2.2</dep.guice.version>
+        <dep.guice.version>4.2.3</dep.guice.version>
         <dep.guava.version>26.0-jre</dep.guava.version>
         <dep.slf4j.version>1.7.30</dep.slf4j.version>
         <dep.logback.version>1.2.3</dep.logback.version>


### PR DESCRIPTION
slf4j to 1.7.30 (http://www.slf4j.org/news.html)
jackson to 2.10.3 (https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10.3)
guice to 4.2.3 (https://github.com/google/guice/wiki/Guice423)