### PR TITLE
Exclude guava's annotations dependencies

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -1037,6 +1037,26 @@
                         <groupId>com.google.guava</groupId>
                         <artifactId>listenablefuture</artifactId>
                     </exclusion>
+                    <!-- exclude optional annotations -->
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                    <!-- exclude optional annotations -->
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <!-- exclude optional annotations -->
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <!-- exclude optional annotations -->
+                    <exclusion>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
Reference https://github.com/prestosql/presto/blob/03aa1b6f9d9ced2807a33d578384c6e05a6f939a/presto-jdbc/pom.xml#L62-L83:

> ```
> <dependency>
>     <groupId>com.google.guava</groupId>
>     <artifactId>guava</artifactId>
>     <exclusions>
>         <exclusion>
>             <groupId>org.checkerframework</groupId>
>             <artifactId>checker-qual</artifactId>
>         </exclusion>
>         <exclusion>
>             <groupId>com.google.errorprone</groupId>
>             <artifactId>error_prone_annotations</artifactId>
>         </exclusion>
>         <exclusion>
>             <groupId>com.google.j2objc</groupId>
>             <artifactId>j2objc-annotations</artifactId>
>         </exclusion>
>         <exclusion>
>             <groupId>org.codehaus.mojo</groupId>
>             <artifactId>animal-sniffer-annotations</artifactId>
>         </exclusion>
>     </exclusions>
> </dependency>
> ```