### PR TITLE
Downgrade git-commit-id-plugin to 4.0.0 (from 4.0.2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 104
+
+* Plugin updates:
+  - git-commit-id-plugin 4.0.0 (from 4.0.2)
+
 Airbase 103
 
 * Dependency updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -522,7 +522,8 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.2</version>
+                    <!-- Version 4.0.2 is broken in PrestoSQL, probably related to: https://bugs.eclipse.org/bugs/show_bug.cgi?id=564202 -->
+                    <version>4.0.0</version>
                     <configuration>
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
                         <gitDescribe>


### PR DESCRIPTION
Previous update to 4.0.2 broke PrestoSQL during compilation:

[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:4.0.2:revision (default) on project presto-spi: Could not complete Mojo execution... Task java.util.concurrent.CompletableFuture$AsyncSupply@78e305f1 rejected from java.util.concurrent.ThreadPoolExecutor@67cff96d[Running, pool size = 5, active threads = 5, queued tasks = 0, completed tasks = 0] -> [Help 1]