### PR TITLE
Configure git-commit-id-plugin to reduce build times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 Airbase 104
 
+* Speed up build by including only relevant properties in git-commit-id-plugin configuration
+
 * Plugin updates:
   - git-commit-id-plugin 4.0.3 (from 4.0.2)
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -524,6 +524,12 @@
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>4.0.3</version>
                     <configuration>
+                        <!-- Include only properties used above to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>\Qgit.build.time</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.commit.id</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.commit.id.describe</includeOnlyProperty>
+                        </includeOnlyProperties>
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
                         <gitDescribe>
                             <tags>true</tags>


### PR DESCRIPTION
Tested on PrestoSQL (`./mvnw -pl '!presto-server-rpm,!presto-docs,!presto-proxy,!presto-verifier' clean install -TC2 -nsu -DskipTests`)


Before:

```
[INFO] Total time:  04:43 min (Wall Clock)
```

After:

```
Total time:  03:26 min (Wall Clock)
```

All credit goes to @hashhar (see https://github.com/prestosql/presto/pull/5817)
