### PR TITLE
Remove errorprone-compiler profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Airbase 106
 
+* Remove `errorprone-compiler` profile.
 * Dependency updates:
   - Apache BVal 2.0.5 (from 2.0.0)
   - Guava 30.1-jre (from 29.0-jre)

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -1341,31 +1341,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>errorprone-compiler</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerId>javac-with-errorprone</compilerId>
-                            <compilerArgs>
-                                <arg>-XepDisableWarningsInGeneratedCode</arg>
-                            </compilerArgs>
-                        </configuration>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.codehaus.plexus</groupId>
-                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.8.3</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!-- ======================================================================== -->
         <!-- =                                                                      = -->
         <!-- = Build a tarball with launcher from a module if .build-airlift        = -->


### PR DESCRIPTION
The profile is not being kept updated. This will let downstream projects
set same-named profile without inheriting any unwanted outdated
configuration.