### PR TITLE
Update checkstyle to 8.40

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Airbase 107
 
+* Plugin updates:
+  - Checkstyle 8.40 (from 8.32)
+
 Airbase 106
 
 * Remove `errorprone-compiler` profile.

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -839,7 +839,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.32</version>
+                            <version>8.40</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->


### PR DESCRIPTION
I wanted to update Checkstyle to 8.39 but it had some regressions that caused false positives in Trino codebase. Version 8.40 has those fixed.