### PR TITLE
Use posix tar mode in assembly-plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 Airbase 107
 
+* Configure maven-assembly-plugin to use posix tar mode
+
 Airbase 106
 
 * Remove `errorprone-compiler` profile.

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -410,8 +410,8 @@
                     <configuration>
                         <!-- must be true for jar-with-dependencies builds -->
                         <appendAssemblyId>true</appendAssemblyId>
-                        <!-- Always use GNU tar mode. -->
-                        <tarLongFileMode>gnu</tarLongFileMode>
+                        <!-- Always use Posix tar mode. -->
+                        <tarLongFileMode>posix</tarLongFileMode>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
The difference between `gnu` and `posix` tar formats is explained here: https://www.gnu.org/software/tar/manual/html_section/tar_67.html#Formats

I think that we are good with switch to `posix` tar mode.

cc @electrum @findepi 