### PR TITLE
Allow using commas in air.javadoc.lint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 112
+
+* Allow using commas in air.javadoc.lint
+
 Airbase 111
 
 * Plugin updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -504,7 +504,7 @@
                         <source>${project.build.targetJdk}</source>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <maxmemory>${air.build.jvmsize}</maxmemory>
-                        <additionalOptions>-Xdoclint:${air.javadoc.lint}</additionalOptions>
+                        <doclint>${air.javadoc.lint}</doclint>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Typical usage would be
```xml
<air.javadoc.lint>all,-missing</air.javadoc.lint>
```
