### PR TITLE
Add junit dependency to surefire plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 112
 
 * Remove cglib
 * Allow using commas in air.javadoc.lint
+* Add JUnit 5.8.0-M1
+* Fix build failure when module does not contain JUnit tests
 
 Airbase 111
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -201,6 +201,7 @@
         <dep.assertj-core.version>3.18.1</dep.assertj-core.version>
         <dep.slice.version>0.39</dep.slice.version>
         <dep.jmh.version>1.20</dep.jmh.version>
+        <dep.junit.version>5.8.0-M1</dep.junit.version>
 
         <!-- license headers -->
         <air.license.owner>${project.organization.name}</air.license.owner>
@@ -463,6 +464,11 @@
                         </argLine>
                     </configuration>
                     <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>${dep.junit.version}</version>
+                        </dependency>
                         <dependency>
                             <groupId>org.apache.maven.surefire</groupId>
                             <artifactId>surefire-junit-platform</artifactId>
@@ -1290,6 +1296,14 @@
                 </exclusions>
             </dependency>
 
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <type>pom</type>
+                <version>${dep.junit.version}</version>
+                <scope>import</scope>
+            </dependency>
+            
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
Otherwise, it causes a build failure unless the project includes
it directly (i.e., as a consequence of containing junit-based tests)