### PR TITLE
Checkstyle version 8.1

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -875,7 +875,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.41.1</version>
+                            <version>9.1</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->


### PR DESCRIPTION
Checkstyle v 9.1 fixes incorrect errors on switch expressions that
assign to a variable. E.g.

```
String s = switch(foo) {
    case A -> "it's a";
    default -> "it's not a";
};
```

The current version generates an error for this.