### PR TITLE
Exclude conflicting dependencies

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -1241,6 +1241,16 @@
                 <groupId>org.apache.bval</groupId>
                 <artifactId>bval-jsr</artifactId>
                 <version>${dep.bval.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.osgi</groupId>
+                        <artifactId>org.osgi.core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The latest version of the extra-enforcer-rules plugin now enforces
dependencies of the "provided" scope. The osgi and jaxb-runtime
dependencies now creating a conflict with other dependencies in the
project