### PR TITLE
Update checkstyle to 9.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 116
+
+* Plugin updates:
+  - Checkstyle 9.2 (from 9.1)
+
 Airbase 114
 
 * Dependency updates

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -879,7 +879,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.1</version>
+                            <version>9.2</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->


### PR DESCRIPTION
Fixes an issue where it will report an error for string literals that
contain spaces at the end.