### PR TITLE
Only enable check plugins if air.check.skip-* is false

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -907,6 +907,7 @@
         </pluginManagement>
 
         <!-- This is the list of plugins used for the main build. -->
+        <!-- Check plugins (except dependency-plugin) are enabled using profiles. -->
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -945,52 +946,7 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>dependency-scope-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.gaul</groupId>
-                <artifactId>modernizer-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -1300,6 +1256,159 @@
     </dependencyManagement>
 
     <profiles>
+        <profile>
+            <id>enforcer-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-enforcer</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>duplicate-finder-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-duplicate-finder</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>dependency-scope-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-dependency-scope</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.hubspot.maven.plugins</groupId>
+                        <artifactId>dependency-scope-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>spotbugs-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-spotbugs</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pmd-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-pmd</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>license-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-license</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jacoco-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-jacoco</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>modernizer-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-modernizer</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.gaul</groupId>
+                        <artifactId>modernizer-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>checkstyle-check</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-checkstyle</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>oss-release</id>
             <properties>


### PR DESCRIPTION
Enable check plugins only when matching `air.check.skip-*` properties are false. This is supposed to avoid any unnecessary initialization overhead. Another minor improvement is that Maven output is not polluted with unused plugins.

I noticed #69 and I've seen similar issues when disabling the dependency plugin so this is the only check plugin that's skipped using configuration.

Tested roughly (only 3 runs of every goal) by running the following goals in [the Trino](https://github.com/trinodb/trino) project, on an otherwise idle r5.large instance:
* clean
* clean install
* install - doesn't require warm-up since it's run after `clean install`

To make tests quicker, I skip the 3 largest modules, this still leaves out 76 modules to be built.
```
flags='--strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"'
hyperfine --min-runs 3 "./mvnw clean $flags" "./mvnw install $flags" "./mvnw clean install $flags"
```

Baseline (Trino master - f7226865e8578339b4e56658b5ec116b872a59c6) yields:
```
Benchmark 1: ./mvnw clean --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"
  Time (mean ± σ):      4.660 s ±  0.807 s    [User: 8.118 s, System: 0.627 s]
  Range (min … max):    4.112 s …  5.587 s    3 runs
 
Benchmark 2: ./mvnw clean install --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"
  Time (mean ± σ):     231.206 s ±  0.780 s    [User: 335.105 s, System: 15.552 s]
  Range (min … max):   230.722 s … 232.106 s    3 runs
 
Benchmark 3: ./mvnw install --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"
  Time (mean ± σ):     172.580 s ±  0.755 s    [User: 206.465 s, System: 12.195 s]
  Range (min … max):   171.715 s … 173.102 s    3 runs
 ```

After changes - setting airbase to 120-SNAPSHOT in root pom.xml:
```
Benchmark 1: ./mvnw clean --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"
  Time (mean ± σ):      4.829 s ±  0.493 s    [User: 8.295 s, System: 0.725 s]
  Range (min … max):    4.430 s …  5.379 s    3 runs
 
Benchmark 2: ./mvnw clean install --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"
  Time (mean ± σ):     228.048 s ±  0.667 s    [User: 324.894 s, System: 15.999 s]
  Range (min … max):   227.287 s … 228.532 s    3 runs
 
Benchmark 3: ./mvnw install --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl "!:trino-server,!:trino-server-rpm,!docs"
  Time (mean ± σ):     169.230 s ±  1.135 s    [User: 202.097 s, System: 12.201 s]
  Range (min … max):   168.043 s … 170.306 s    3 runs
```

The gain is small (3s, ~1%) but visible.

I'm also attaching flame graphs from the async-profiler, that shows a 2% difference in how much time (samples) is used for the GC and JIT.
[mvn-profiles.zip](https://github.com/airlift/airbase/files/7846719/mvn-profiles.zip)
