### PR TITLE
Update guice to 5.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 120
 
 * Checkstyle updates:
   - Add `LCURLY` to `WhitespaceAround` to catch more whitespace issues
+* Dependency updates:
+  - Guice 5.1.0 (from 5.0.1)
 
 Airbase 119
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -186,7 +186,7 @@
         <dep.packaging.version>0.163</dep.packaging.version>
 
         <!-- Dependency versions that should be the same everywhere. -->
-        <dep.guice.version>5.0.1</dep.guice.version>
+        <dep.guice.version>5.1.0</dep.guice.version>
         <dep.guava.version>31.0.1-jre</dep.guava.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <dep.logback.version>1.2.3</dep.logback.version>


### PR DESCRIPTION
This version brings compatibility with JDK17+

See: https://github.com/google/guice/wiki/Guice510