### PR TITLE
Define default `argLine` property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 121
+
+* Fix Surefire setup when JaCoCo is disabled
+
 Airbase 120
 
 * Add dependencies:
@@ -9,7 +13,7 @@ Airbase 120
   - Joda-Time 2.10.13 (from 2.10.10)
 * Plugin updates:
   - update maven-compiler-plugin 3.9.0 (from 3.8.1)
-  
+
 Airbase 119
 
 * Remove `air.test.skip` property. Use `skipTests` instead.

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -1384,6 +1384,19 @@
             </build>
         </profile>
         <profile>
+            <id>jacoco-defaults</id>
+            <activation>
+                <property>
+                    <name>air.check.skip-jacoco</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- ${argLine} is defined by Jacoco, but required by Surefire, so define an empty default when Jacoco is disabled -->
+                <argLine />
+            </properties>
+        </profile>
+        <profile>
             <id>modernizer-check</id>
             <activation>
                 <property>


### PR DESCRIPTION
Define an empty default value for the `argLine` property, required when `air.check.skip-jacoco` is true. This was introduced in the 120 version, where unused plugins are disabled completely.