### PR TITLE
Allow configuring if existing headers should be skipped in license check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 124
+
+* When checking license headers do not skip the files which already contain a
+  detected license header. Can be configured via `air.license.skip-existing-headers`.
+
 Airbase 123
 
 * Dependency update:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -210,6 +210,7 @@
         <air.license.default-value>Copyright (C) ${project.inceptionYear} ${air.license.owner}</air.license.default-value>
         <air.license.ensure-match>Copyright \(C\) \d{4} .+</air.license.ensure-match>
         <air.license.header-file>license/apache-header.txt</air.license.header-file>
+        <air.license.skip-existing-headers>false</air.license.skip-existing-headers>
 
         <!-- Checkstyle -->
         <air.checkstyle.config-file>checkstyle/airbase-checks.xml</air.checkstyle.config-file>
@@ -738,7 +739,7 @@
                     </dependencies>
                     <configuration>
                         <skip>${air.check.skip-license}</skip>
-                        <skipExistingHeaders>true</skipExistingHeaders>
+                        <skipExistingHeaders>${air.license.skip-existing-headers}</skipExistingHeaders>
                         <failIfMissing>${air.check.fail-license}</failIfMissing>
                         <header>${air.license.header-file}</header>
                         <mapping>


### PR DESCRIPTION
All credit to @findinpath for finding this.

See for source https://github.com/trinodb/trino/pull/11563#issuecomment-1072302541

cc: @findinpath @findepi 