### PR TITLE
Update maven-dependency-plugin to 3.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 123
 
 * Dependency update:
   - Guava 31.1-jre (from 31.0.1-jre)
+* Plugin updates:
+  - maven-dependency-plugin 3.3.0 (from 3.1.2)
 
 Airbase 122
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -361,26 +361,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
-                    <dependencies>
-                        <!-- TODO: remove when plugin is updated -->
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.1</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>1.11.3</version>
-                            <exclusions>
-                                <exclusion>
-                                    <artifactId>maven-project</artifactId>
-                                    <groupId>org.apache.maven</groupId>
-                                </exclusion>
-                            </exclusions>
-                        </dependency>
-                    </dependencies>
+                    <version>3.3.0</version>
                     <configuration>
                         <skip>${air.check.skip-dependency}</skip>
                         <failOnWarning>${air.check.fail-dependency}</failOnWarning>


### PR DESCRIPTION
This version is compatible with JDK 16+:

```
Release Notes - Maven Dependency Plugin - Version 3.3.0

** Bug
* [MDEP-679] - mvn dependency:analyze detected wrong transitive
dependency
* [MDEP-742] - dependency plugin does not work with JDK 16
* [MDEP-752] - skip dependency analyze in ear packaging
* [MDEP-753] - Non-test dependency reported as Non-test scoped test
only dependency
* [MDEP-759] - 'Dependency not found' with 3.2.0 and Java-17 while
analyzing
* [MDEP-761] - Tree plugin does not terminate with 3.2.0
* [MDEP-769] - Minor improvement - continue
* [MDEP-774] - analyze-only failed: PermittedSubclasses requires ASM9
* [MDEP-781] - Broken Link to "Introduction to Dependency Mechanism
Page"
* [MDEP-783] - TreeMojo docs say scope doesn't work due to MSHARED-4
* [MDEP-786] - Sealed classes not supported

** New Feature
* [MDEP-787] - Allow ignoring non-test-scoped dependencies

** Improvement
* [MDEP-763] - Minor improvements
* [MDEP-768] - GitHub Action build improvement
* [MDEP-779] - dependency:analyze should list the classes that cause a
used undeclared dependency
* [MDEP-789] - Improve documentation of analyze - Non-test scoped

** Task
* [MDEP-760] - Java 1.8 as minimum

** Dependency upgrade
* [MDEP-766] - Upgrade maven-invoker-plugin to version 3.2.2
* [MDEP-784] - Upgrade maven-dependency-analyzer to 1.12.0
* [MDEP-788] - Upgrade maven-reporting-impl to version 3.1.0
* [MDEP-795] - Update Jetty to 9.4.45.v20220203
* [MDEP-796] - Upgrade Maven Parent to 35
* [MDEP-797] - Update transitive dependency commons-beanutils to 1.9.4
* [MDEP-798] - Upgrade maven-dependency-tree from 3.0.1 to 3.1.0

```