### PR TITLE
Update Surefire plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 124
 
 * Dependency updates:
   - Slice 0.42 (from 0.41)
+* Plugin updates:
+  - Surefire 3.0.0-M6 (from 3.0.0-M5)
 
 Airbase 123
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -180,7 +180,7 @@
 
         <!-- Plugin versions used in multiple places -->
         <dep.plugin.scm.version>1.8.1</dep.plugin.scm.version>
-        <dep.plugin.surefire.version>3.0.0-M5</dep.plugin.surefire.version>
+        <dep.plugin.surefire.version>3.0.0-M6</dep.plugin.surefire.version>
 
         <!-- Packaging for the tarball deployment -->
         <dep.packaging.version>0.163</dep.packaging.version>


### PR DESCRIPTION
The new version includes https://github.com/apache/maven-surefire/pull/407 which should reduce memory usage in CI and help avoid failures caused by running out of memory.