### PR TITLE
Disallow shaded org.apache imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Airbase 126
 
 * Fix the way locale information is passed to maven-surefire-plugin
+* Checkstyle updates:
+  - Forbid imports of shaded Apache code
 * Dependency updates:
   - Logback 1.2.11 (from 1.2.3)
 * Plugin downgrades:

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -247,6 +247,8 @@
             <!-- Shaded okhttp3; match "shaded", since "com.example.okhttp3" could be OkHttp-specific code within com.example -->
             <property name="illegalPkgs" value=".*\.shaded\.okhttp3" />
             <property name="regexp" value="true" />
+            <!-- Shaded org.apache code -->
+            <property name="illegalPkgs" value=".*\.shaded\.org\.apache" />
         </module>
 
         <module name="MethodName">


### PR DESCRIPTION
Lot of dependencies shade Apache code and it's easy to import from them
by mistake which often breaks once dependencies are updated and have
improved their exclusions/shading.