### PR TITLE
Allow using "extends" and "implements" in a Java comment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 125
+
+* Checkstyle updates:
+  - Allow using "extends" and "implements" in a Java comment.
+
 Airbase 124
 
 * Dependency updates:

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -44,10 +44,6 @@
         <property name="format" value="->(\s*+(//.*+)?\n)++\s*+\{" />
         <property name="message" value="Lambda opening brace should be on the same line as ->" />
     </module>
-    <module name="RegexpSingleline">
-        <property name="format" value="(class|interface) ([a-zA-Z0-9_])+(&lt;.*&gt;)? (extends|implements)" />
-        <property name="message" value="No new line before extends/implements" />
-    </module>
 
     <module name="RegexpSingleline">
         <property name="format" value="^import static .*\.(of|copyOf|valueOf);$" />
@@ -255,6 +251,12 @@
 
         <module name="MethodName">
             <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="(class|interface) ([a-zA-Z0-9_])+(&lt;.*&gt;)? (extends|implements)" />
+            <property name="message" value="No new line before extends/implements" />
+            <property name="ignoreComments" value="true" />
         </module>
     </module>
 </module>


### PR DESCRIPTION
For example a comment like below was previously flagged as invalid.

```
/**
 * A class that implements ...
```