### PR TITLE
Fix the way locale information is passed to Surefire

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 126
+
+* Fix the way locale information is passed to maven-surefire-plugin
+
 Airbase 125
 
 * Checkstyle updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -426,9 +426,6 @@
                     <configuration>
                         <systemPropertyVariables>
                             <sun.jnu.encoding>${project.build.sourceEncoding}</sun.jnu.encoding>
-                            <user.timezone>${air.test.timezone}</user.timezone>
-                            <user.language>${air.test.language}</user.language>
-                            <user.region>${air.test.region}</user.region>
                             <java.awt.headless>true</java.awt.headless>
                             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS.%1$tL%1$tz %4$s %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
                         </systemPropertyVariables>
@@ -440,6 +437,13 @@
                         <!-- ${argLine} is for Jacoco: https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html -->
                         <argLine>
                             ${argLine}
+
+                            <!-- Pass the following three directly to the JVM,
+                                 because systemPropertyVariables are not passed correctly by Maven -->
+                            -Duser.timezone=${air.test.timezone}
+                            -Duser.language=${air.test.language}
+                            -Duser.region=${air.test.region}
+
                             -Dfile.encoding=${project.build.sourceEncoding}
                             -Xmx${air.test.jvmsize}
                             -Xms${air.test.jvmsize}


### PR DESCRIPTION
This moves primarily the `user.language` and `user.region` from `systemPropertyVariables` to explicit property setting on the JVM. These two methods to set them are supposed to be the same, but passing via system properties does not actually work. Which is annoying, because when the are set in both ways, Surefire complains about it:

```
[WARN] The system property user.language is configured twice! The property appears in <argLine/> and any of <systemPropertyVariables/>, <systemProperties/> or user property.
[WARN] The system property user.region is configured twice! The property appears in <argLine/> and any of <systemPropertyVariables/>, <systemProperties/> or user property.
```

It seems that the `user.timezone` actually works as expected, but is moved along with the other two for consistency.