### PR TITLE
Always declare empty argLine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 128
 
 * Plugin updates:
   - JaCoCo 0.8.8 (from 0.8.7)
+* Always define ``argLine`` property even if Jacoco is disabled, to ensure
+  that Surefire configuration does not confuse IntelliJ IDEA
 
 Airbase 127
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -178,6 +178,10 @@
         <!-- See http://stackoverflow.com/questions/1012402/maven2-property-that-indicates-the-parent-directory    -->
         <air.main.basedir>${project.basedir}</air.main.basedir>
 
+        <!-- ${argLine} is used by Jacoco to store commands to enable its agent, and then used in Surefire configuration.
+             When Jacoco is not enabled, it will stay empty, otherwise it will be overwritten. -->
+        <argLine />
+
         <!-- Plugin versions used in multiple places -->
         <dep.plugin.scm.version>1.8.1</dep.plugin.scm.version>
         <dep.plugin.surefire.version>3.0.0-M5</dep.plugin.surefire.version>
@@ -434,9 +438,9 @@
                         <failIfNoTests>true</failIfNoTests>
                         <parallel>${air.test.parallel}</parallel>
                         <threadCount>${air.test.thread-count}</threadCount>
-                        <!-- ${argLine} is for Jacoco: https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html -->
+                        <!-- @{argLine} is for Jacoco: https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html -->
                         <argLine>
-                            ${argLine}
+                            @{argLine}
 
                             <!-- Pass the following three directly to the JVM,
                                  because systemPropertyVariables are not passed correctly by Maven -->
@@ -1372,20 +1376,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>jacoco-defaults</id>
-            <activation>
-                <property>
-                    <name>air.check.skip-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <!-- ${argLine} is defined by Jacoco, but required by Surefire, so define an empty default
-                when Jacoco is disabled with all checks -->
-                <argLine />
-            </properties>
         </profile>
         <profile>
             <id>modernizer-check</id>


### PR DESCRIPTION
The `argLine` property is used by Jacoco to store the JVM commands which enable its agent. It is initialized by the Jacoco plugin, then used in the Surefire configuration. But when Jacoco is disabled (e.g. using the `air.check.skip-jacoco` property), the `argLine` property is not initialized, and if we don't take additional measures, it will appear as literal `${argLine}` in Surefire's JVM arguments line, which may cause trouble with some tools. The way it was handled previously was that there was an additional profile, which was supposed to be activated when Jacoco was disabled, and which initialized the `argLine` property to empty, allowing Maven to properly interpolate it in the Surefire configuration.

There was one problem with this solution, though - these are system properties, not Maven properties, and profile activation is done before property values are resolved. So if we have a project which disables Jacoco explicitly in its POM (by overriding the property like this: `<air.check.skip-jacoco>true</air.check.skip-jacoco>`), this did not change the set of active profiles. This means that the Jacoco plugin was still configured - though disabled - and the prifile to initialize the `argLine` property was still not active. Thus, when the Surefire configuration was evaluated, the `argLine` property was uninitialized.

The fix in this commit unconditionally initializes `argLine` to empty. This way if Jacoco is enabled, the Jacoco plugin will overwrite this property; otherwise it will remain empty. But for this to work we have to change the Surefire configuration to use late evaluation for `argLine` to prevent its evaluation before it's reinitialized by the Jacoco plugin.