### PR TITLE
Update dependencies: slf4j, joda-time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Airbase 129
 
 * Dependency updates:
+  - joda-time 2.10.14 (from 2.10.13)
   - slf4j 1.7.36 (from 1.7.32)
 
 Airbase 128

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 129
+
+* Dependency updates:
+  - slf4j 1.7.36 (from 1.7.32)
+
 Airbase 128
 
 * Plugin updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -200,7 +200,7 @@
         <dep.bval.version>2.0.5</dep.bval.version>
         <dep.jackson.version>2.13.3</dep.jackson.version>
         <dep.jmxutils.version>1.21</dep.jmxutils.version>
-        <dep.joda.version>2.10.13</dep.joda.version>
+        <dep.joda.version>2.10.14</dep.joda.version>
         <dep.spotbugs-annotations.version>4.3.0</dep.spotbugs-annotations.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.18.1</dep.assertj-core.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -192,7 +192,7 @@
         <!-- Dependency versions that should be the same everywhere. -->
         <dep.guice.version>5.1.0</dep.guice.version>
         <dep.guava.version>31.1-jre</dep.guava.version>
-        <dep.slf4j.version>1.7.32</dep.slf4j.version>
+        <dep.slf4j.version>1.7.36</dep.slf4j.version>
         <dep.logback.version>1.2.11</dep.logback.version>
         <dep.javax-inject.version>1</dep.javax-inject.version>
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>


### PR DESCRIPTION
Update slf4j to be able to update testcontainers to the latest version, since it also depends on slf4j.

Update joda-time to the latest version. This brings back some timezones removed earlier: https://www.joda.org/joda-time/changes-report.html#a2.10.14