### PR TITLE
Update spotbugs-annotations and modernizer version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Airbase 129
   - Require package name to match the source directory
 * Dependency updates:
   - spotbugs-annotations 4.7.2 (from 4.3.0)
+  - modernizer 2.4.0 (from 2.3.0)
   - joda-time 2.10.14 (from 2.10.13)
   - slf4j 1.7.36 (from 1.7.32)
   - checkstyle 10.3.2 (from 9.2)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Airbase 129
 * Checkstyle updates:
   - Require package name to match the source directory
 * Dependency updates:
+  - spotbugs-annotations 4.7.2 (from 4.3.0)
   - joda-time 2.10.14 (from 2.10.13)
   - slf4j 1.7.36 (from 1.7.32)
   - checkstyle 10.3.2 (from 9.2)

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -205,7 +205,7 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.18.1</dep.assertj-core.version>
         <dep.slice.version>0.42</dep.slice.version>
-        <dep.modernizer.version>2.3.0</dep.modernizer.version>
+        <dep.modernizer.version>2.4.0</dep.modernizer.version>
         <dep.jmh.version>1.32</dep.jmh.version>
         <dep.junit.version>5.8.1</dep.junit.version>
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -201,7 +201,7 @@
         <dep.jackson.version>2.13.3</dep.jackson.version>
         <dep.jmxutils.version>1.21</dep.jmxutils.version>
         <dep.joda.version>2.10.14</dep.joda.version>
-        <dep.spotbugs-annotations.version>4.3.0</dep.spotbugs-annotations.version>
+        <dep.spotbugs-annotations.version>4.7.2</dep.spotbugs-annotations.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.18.1</dep.assertj-core.version>
         <dep.slice.version>0.42</dep.slice.version>


### PR DESCRIPTION
I browsed the changelog and I didn't see any breaking changes, mostly updated dependencies, fixes, and new checks. I also built Trino with this snapshot of Airbase and it was successful.

Same for modernizer.