### PR TITLE
Upgrade checkstyle to 10.3.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Airbase 129
 * Dependency updates:
   - joda-time 2.10.14 (from 2.10.13)
   - slf4j 1.7.36 (from 1.7.32)
+  - checkstyle 10.3.2 (from 9.2)
 
 Airbase 128
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -837,7 +837,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.2</version>
+                            <version>10.3.2</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->


### PR DESCRIPTION
Tested on current Trino master. Does not yield new violations for existing code.