### PR TITLE
Suppress Checkstyle within text-blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Airbase 129
 
 * Checkstyle updates:
   - Require package name to match the source directory
+  - Suppress Checkstyle within text-blocks
 * Dependency updates:
   - joda-time 2.10.14 (from 2.10.13)
   - slf4j 1.7.36 (from 1.7.32)

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -3,6 +3,13 @@
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 <module name="Checker">
+    <!-- TODO: Remove this supression once RegexpMultiline has been replaced with an AST aware check -->
+    <!-- This suprpresses Checkstyle between onccurences of """", i.e. text blocks -->
+    <module name="SuppressWithPlainTextCommentFilter">
+        <property name="offCommentFormat" value='=\s+"""'/>
+        <property name="onCommentFormat" value='^\s+.*""";'/>
+    </module>
+
     <module name="FileTabCharacter" />
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf" />


### PR DESCRIPTION
Some checks like RegexpMultiline are not AST aware and hence cannot
differentiate between content inside a text-block or outside of it. This
is a short term workaround which uses the """ text as a marker to let
Checkstyle suppress any violations between them.

The longer term fix is to migrate away from non-AST aware checks like
RegexpMultiline and RegexpSingleline to something else.

cc: @kokosing @martint 

Fixes https://github.com/trinodb/trino/issues/14623