### PR TITLE
Enforce no redundant modifiers in interfaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 Airbase 131
 
+* Checkstyle updates:
+  - Disallow redundant modifiers on interface elements
 * Plugin updates:
   - PMD 3.19.0 (from 3.12.0)
 

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -113,6 +113,12 @@
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder" />
 
+        <module name="SuppressionXpathSingleFilter">
+            <property name="checks" value="RedundantModifier"/>
+            <property name="query" value="//CLASS_DEF/OBJBLOCK/*/MODIFIERS/*"/>
+        </module>
+        <module name="RedundantModifier" />
+
         <module name="EmptyBlock">
             <property name="option" value="text" />
             <property name="tokens" value="


### PR DESCRIPTION
Enforce interface methods have no redundant modifiers (like `public`). The checkstyle's `RedundantModifier` applies to interface and classes as well. In private classes it flags `public` methods as having redundant modifiers. It is technically correct, but some projects (like Trino) choose to use `public` in private classes for documenting the "internal interface" of a class. Thus, the check is suppressed inside class definitions (but still applies to interfaces inside classes).

Fixes https://github.com/airlift/airbase/issues/174