### PR TITLE
Use ISO-8859-1 when filtering properties files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 144
+
+* Use standard properties encoding, ISO-8859-1, when filtering properties file.
+
 Airbase 143
 
 * Relax restricted imports for Jersey

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -470,12 +470,14 @@
                     </configuration>
                 </plugin>
 
-                <!-- Resource plugins should always use UTF-8 -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                     <configuration>
+                        <!-- Properties files are ISO-8859-1 by default -->
+                        <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+                        <!-- Use project encoding (e.g. UTF-8) for all other resources -->
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Properties files are standardized to be encoded with ISO-8859-1. maven-resources-plug now allows setting a specific encoding for properties files and even generates a build-time message when this configuration is not used.

This can be e.g. observed in a Trino build

    [INFO] --- maven-resources-plugin:3.2.0:resources (default-resources) @ trino-testing-services ---
    [INFO] Using 'UTF-8' encoding to copy filtered resources.
    [INFO] Using 'UTF-8' encoding to copy filtered properties files.
    [INFO] Copying 1 resource
    [INFO] Copying 1 resource
    [INFO] The encoding used to copy filtered properties files have not
    been set. This means that the same encoding will be used to copy
    filtered properties files as when copying other filtered resources. This
    might not be what you want! Run your build with --debug to see which
    files might be affected. Read more at
    https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html