### PR TITLE
Require empty line before javadoc tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Airbase 133
 
 * Checkstyle updates:
+  - Disallow empty javadoc tags
   - Require empty line before javadoc tags
 
 Airbase 132

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 133
+
+* Checkstyle updates:
+  - Require empty line before javadoc tags
+
 Airbase 132
 
 * Checkstyle updates:

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -267,5 +267,8 @@
             <property name="message" value="No new line before extends/implements" />
             <property name="ignoreComments" value="true" />
         </module>
+
+        <!-- javadoc -->
+        <module name="RequireEmptyLineBeforeBlockTagGroup" />
     </module>
 </module>

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -270,5 +270,6 @@
 
         <!-- javadoc -->
         <module name="RequireEmptyLineBeforeBlockTagGroup" />
+        <module name="NonEmptyAtclauseDescription" />
     </module>
 </module>


### PR DESCRIPTION
I.e. a line that IntelliJ formatter would insert.