### PR TITLE
Enable requirePluginVersions in enforcer plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 134
+
+* Enforcer updates:
+  - Enable `requirePluginVersions` check
+
 Airbase 133
 
 * Checkstyle updates:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 134
 
 * Enforcer updates:
   - Enable `requirePluginVersions` check
+* Plugin updates:
+  - Enforcer 3.2.1 (from 3.1.0)
 
 Airbase 133
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -283,7 +283,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.codehaus.mojo</groupId>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -359,6 +359,9 @@
                                     <exclude>org.eclipse.jetty:jetty-alpn-java-server</exclude>
                                 </excludes>
                             </enforceBytecodeVersion>
+                            <requirePluginVersions>
+                                <message>Providing the plugin version explicitly makes the builds reproducible</message>
+                            </requirePluginVersions>
                         </rules>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
As the configured error message says, providing a version is important for build stability.

Also, bump Enforcer to the latest version.