### PR TITLE
Remove read-only inputEncoding parameter from PMD

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -690,7 +690,6 @@
                         <skip>${air.check.skip-pmd}</skip>
                         <failOnViolation>${air.check.fail-pmd}</failOnViolation>
                         <targetJdk>${project.build.targetJdk}</targetJdk>
-                        <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
                         <minimumTokens>100</minimumTokens>
                         <excludes>
                             <exclude>**/*Bean.java</exclude>


### PR DESCRIPTION
Maven now warns about this:
```
[WARN] Parameter 'inputEncoding' (user property 'encoding') is read-only, must not be used in configuration
