### PR TITLE
Add OpenTelemetry dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Airbase 135
 
 * Run compiler in same process by default
 * Allow dependency plugin to work with Java 21 bytecode
+* Checkstyle updates:
+  - Version 10.9.3 (from 10.8.0)
 * Dependency updates:
   - Pinned versions some more Jackson modules
   - SLF4J 2.0.7 (from 2.0.6)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Airbase 135
 * Dependency updates:
   - Pinned versions some more Jackson modules
   - SLF4J 2.0.7 (from 2.0.6)
+  - Logback 1.4.6 (from 1.4.5)
   - joda-time 2.12.5 (from 2.11.2)
 * Plugin updates:
   - Modernizer 2.6.0 (from 2.5.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Airbase 135
 
 * Run compiler in same process by default
+* Allow dependency plugin to work with Java 21 bytecode
 * Dependency updates:
   - Pinned versions some more Jackson modules
   - SLF4J 2.0.7 (from 2.0.6)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Airbase 135
 * Dependency updates:
   - Pinned versions some more Jackson modules
   - SLF4J 2.0.7 (from 2.0.6)
+  - joda-time 2.12.5 (from 2.11.2)
 * Plugin updates:
   - Modernizer 2.6.0 (from 2.5.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Airbase 135
 * Allow dependency plugin to work with Java 21 bytecode
 * Checkstyle updates:
   - Version 10.9.3 (from 10.8.0)
+* Add dependencies:
+  - OpenTelemetry
+  - Kotlin
 * Dependency updates:
   - Pinned versions some more Jackson modules
   - SLF4J 2.0.7 (from 2.0.6)

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -202,7 +202,7 @@
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
         <dep.jmh.version>1.36</dep.jmh.version>
         <dep.jmxutils.version>1.22</dep.jmxutils.version>
-        <dep.joda.version>2.12.2</dep.joda.version>
+        <dep.joda.version>2.12.5</dep.joda.version>
         <dep.junit.version>5.9.2</dep.junit.version>
         <dep.logback.version>1.4.5</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -204,8 +204,11 @@
         <dep.jmxutils.version>1.22</dep.jmxutils.version>
         <dep.joda.version>2.12.5</dep.joda.version>
         <dep.junit.version>5.9.2</dep.junit.version>
+        <dep.kotlin.version>1.8.20</dep.kotlin.version>
         <dep.logback.version>1.4.6</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>
+        <dep.opentelemetry.version>1.25.0</dep.opentelemetry.version>
+        <dep.opentelemetry-instrumentation.version>1.24.0</dep.opentelemetry-instrumentation.version>
         <dep.slf4j.version>2.0.7</dep.slf4j.version>
         <dep.slice.version>0.45</dep.slice.version>
         <dep.spotbugs-annotations.version>4.7.3</dep.spotbugs-annotations.version>
@@ -1101,6 +1104,48 @@
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
                 <version>${dep.jackson.version}</version>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Kotlin -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <type>pom</type>
+                <version>${dep.kotlin.version}</version>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- OpenTelemetry -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <type>pom</type>
+                <version>${dep.opentelemetry.version}</version>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <type>pom</type>
+                <version>${dep.opentelemetry.version}-alpha</version>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <type>pom</type>
+                <version>${dep.opentelemetry-instrumentation.version}</version>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+                <type>pom</type>
+                <version>${dep.opentelemetry-instrumentation.version}-alpha</version>
                 <scope>import</scope>
             </dependency>
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -204,7 +204,7 @@
         <dep.jmxutils.version>1.22</dep.jmxutils.version>
         <dep.joda.version>2.12.5</dep.joda.version>
         <dep.junit.version>5.9.2</dep.junit.version>
-        <dep.logback.version>1.4.5</dep.logback.version>
+        <dep.logback.version>1.4.6</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>
         <dep.slf4j.version>2.0.7</dep.slf4j.version>
         <dep.slice.version>0.45</dep.slice.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -851,7 +851,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>10.8.0</version>
+                            <version>10.9.3</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -373,6 +373,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.5.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>9.5</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <skip>${air.check.skip-dependency}</skip>
                         <failOnWarning>${air.check.fail-dependency}</failOnWarning>


### PR DESCRIPTION
The Kotlin BOM is needed to ensure that the various Kotlin dependencies dragged in by OkHttp have the same version. OkHttp is used by the OpenTelemetry exporters.