### PR TITLE
[Spring cleaning] Plugins and dependencies updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Airbase 139
 * Dependency updates:
   - JUnit 5.9.3 (from 5.9.2)
   - Kotlin 1.8.21 (from 1.8.20)
+  - Opentelemetry 1.26.0 (from 1.25.0)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Airbase 139
   - maven-resources-plugin 3.3.1 (from 3.2.0)
   - maven-assembly-plugin 3.5.0 (from 3.3.0)
   - maven-javadoc-plugin 3.5.0 (from 3.2.0)
+  - maven-jar-plugin 3.3.0 (from 3.2.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Airbase 139
   - license-maven-plugin 4.2 (from 3.0)
   - jacoco-maven-plugin 0.8.10 (from 0.8.9)
   - maven-checkstyle-plugin 3.2.2 (from 3.2.1)
+  - maven-site-plugin 3.12.1 (from 3.2)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Airbase 139
   - maven-enforcer-plugin 3.3.0 (from 3.2.1)
   - maven-resources-plugin 3.3.1 (from 3.2.0)
   - maven-assembly-plugin 3.5.0 (from 3.3.0)
+  - maven-javadoc-plugin 3.5.0 (from 3.2.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Airbase 139
 * Replace checkstyle illegal imports with `RestrictImports` enforcer rules
 * Checkstyle updates:
   - Require throws keyword to be on a new line.
+* Dependency updates:
+  - JUnit 5.9.3 (from 5.9.2)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Airbase 139
   - maven-jar-plugin 3.3.0 (from 3.2.0)
   - migrate to git-commit-id-maven-plugin 5.0.0 (from git-commit-id-plugin 4.0.5)
   - maven-source-plugin 3.2.1 (from 3.2.0)
+  - license-maven-plugin 4.2 (from 3.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Airbase 139
   - maven-install-plugin 3.1.1 (from 2.5.2)
   - maven-enforcer-plugin 3.3.0 (from 3.2.1)
   - maven-resources-plugin 3.3.1 (from 3.2.0)
+  - maven-assembly-plugin 3.5.0 (from 3.3.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Airbase 139
   - Require throws keyword to be on a new line.
 * Dependency updates:
   - JUnit 5.9.3 (from 5.9.2)
+  - Kotlin 1.8.21 (from 1.8.20)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Airbase 139
   - maven-clean-plugin 3.2.0 (from 3.0.0)
   - maven-install-plugin 3.1.1 (from 2.5.2)
   - maven-enforcer-plugin 3.3.0 (from 3.2.1)
+  - maven-resources-plugin 3.3.1 (from 3.2.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Airbase 139
 * Replace checkstyle illegal imports with `RestrictImports` enforcer rules
 * Checkstyle updates:
   - Require throws keyword to be on a new line.
+* Plugin updates:
+  - Surefire 3.1.0 (from 3.0.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Airbase 139
   - Kotlin 1.8.21 (from 1.8.20)
   - Opentelemetry 1.26.0 (from 1.25.0)
   - Opentelemetry Instrumentation 1.25.1 (from 1.24.0)
+  - Logback 1.4.7 (from 1.4.6)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Airbase 139
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
   - maven-clean-plugin 3.2.0 (from 3.0.0)
+  - maven-install-plugin 3.1.1 (from 2.5.2)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Airbase 139
   - maven-assembly-plugin 3.5.0 (from 3.3.0)
   - maven-javadoc-plugin 3.5.0 (from 3.2.0)
   - maven-jar-plugin 3.3.0 (from 3.2.0)
+  - migrate to git-commit-id-maven-plugin 5.0.0 (from git-commit-id-plugin 4.0.5)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Airbase 139
   - Logback 1.4.7 (from 1.4.6)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
+  - maven-clean-plugin 3.2.0 (from 3.0.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Airbase 139
   - Opentelemetry 1.26.0 (from 1.25.0)
   - Opentelemetry Instrumentation 1.25.1 (from 1.24.0)
   - Logback 1.4.7 (from 1.4.6)
+  - Checkstyle 10.11.0 (from 10.9.3)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
   - maven-clean-plugin 3.2.0 (from 3.0.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Airbase 139
   - Opentelemetry Instrumentation 1.25.1 (from 1.24.0)
   - Logback 1.4.7 (from 1.4.6)
   - Checkstyle 10.11.0 (from 10.9.3)
+  - Guice 6.0.0 (from 5.1.0)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
   - maven-clean-plugin 3.2.0 (from 3.0.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Airbase 139
   - maven-source-plugin 3.2.1 (from 3.2.0)
   - license-maven-plugin 4.2 (from 3.0)
   - jacoco-maven-plugin 0.8.10 (from 0.8.9)
+  - maven-checkstyle-plugin 3.2.2 (from 3.2.1)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Airbase 139
   - Surefire 3.1.0 (from 3.0.0)
   - maven-clean-plugin 3.2.0 (from 3.0.0)
   - maven-install-plugin 3.1.1 (from 2.5.2)
+  - maven-enforcer-plugin 3.3.0 (from 3.2.1)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Airbase 139
   - JUnit 5.9.3 (from 5.9.2)
   - Kotlin 1.8.21 (from 1.8.20)
   - Opentelemetry 1.26.0 (from 1.25.0)
+  - Opentelemetry Instrumentation 1.25.1 (from 1.24.0)
 * Plugin updates:
   - Surefire 3.1.0 (from 3.0.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Airbase 139
   - migrate to git-commit-id-maven-plugin 5.0.0 (from git-commit-id-plugin 4.0.5)
   - maven-source-plugin 3.2.1 (from 3.2.0)
   - license-maven-plugin 4.2 (from 3.0)
+  - jacoco-maven-plugin 0.8.10 (from 0.8.9)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Airbase 139
   - maven-javadoc-plugin 3.5.0 (from 3.2.0)
   - maven-jar-plugin 3.3.0 (from 3.2.0)
   - migrate to git-commit-id-maven-plugin 5.0.0 (from git-commit-id-plugin 4.0.5)
+  - maven-source-plugin 3.2.1 (from 3.2.0)
 
 Airbase 138
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Airbase 139
   - jacoco-maven-plugin 0.8.10 (from 0.8.9)
   - maven-checkstyle-plugin 3.2.2 (from 3.2.1)
   - maven-site-plugin 3.12.1 (from 3.2)
+  - maven-scm-plugin 2.0.0 (from 1.8.1)
 
 Airbase 138
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -190,7 +190,7 @@
 
         <!-- Plugin versions used in multiple places -->
         <dep.plugin.scm.version>1.8.1</dep.plugin.scm.version>
-        <dep.plugin.surefire.version>3.0.0</dep.plugin.surefire.version>
+        <dep.plugin.surefire.version>3.1.0</dep.plugin.surefire.version>
         <dep.plugin.pmd-runtime.version>6.55.0</dep.plugin.pmd-runtime.version>
 
         <!-- Packaging for the tarball deployment -->

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -189,7 +189,7 @@
         <argLine />
 
         <!-- Plugin versions used in multiple places -->
-        <dep.plugin.scm.version>1.8.1</dep.plugin.scm.version>
+        <dep.plugin.scm.version>2.0.0</dep.plugin.scm.version>
         <dep.plugin.surefire.version>3.1.0</dep.plugin.surefire.version>
         <dep.plugin.pmd-runtime.version>6.55.0</dep.plugin.pmd-runtime.version>
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -281,7 +281,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.1</version>
                 </plugin>
 
                 <plugin>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -805,7 +805,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>4.2</version>
                     <dependencies>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->
@@ -820,7 +820,43 @@
                         <skip>${air.check.skip-license}</skip>
                         <skipExistingHeaders>${air.license.skip-existing-headers}</skipExistingHeaders>
                         <failIfMissing>${air.check.fail-license}</failIfMissing>
-                        <header>${air.license.header-file}</header>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>${air.license.header-file}</header>
+                                <headerSections>
+                                    <headerSection>
+                                        <key>COPYRIGHT_SECTION</key>
+                                        <defaultValue>${air.license.default-value}</defaultValue>
+                                        <ensureMatch>${air.license.ensure-match}</ensureMatch>
+                                        <multiLineMatch>false</multiLineMatch>
+                                    </headerSection>
+                                </headerSections>
+                                <excludes>
+                                    <exclude>.*/**</exclude>
+                                    <exclude>**/*.md</exclude>
+                                    <exclude>**/*.sh</exclude>
+                                    <exclude>**/*.txt</exclude>
+                                    <exclude>**/*.thrift</exclude>
+                                    <exclude>**/*.sql</exclude>
+                                    <exclude>**/*.releaseBackup</exclude>
+                                    <exclude>**/*.st</exclude>
+                                    <exclude>**/*.raw</exclude>
+                                    <exclude>**/*.ser</exclude>
+                                    <exclude>**/*.html</exclude>
+                                    <exclude>**/*.rst</exclude>
+                                    <exclude>**/*.xml</exclude>
+                                    <exclude>**/*.csv</exclude>
+                                    <exclude>**/*.tsv</exclude>
+                                    <exclude>**/*.properties</exclude>
+                                    <exclude>**/src/license/**</exclude>
+                                    <exclude>**/src/*/resources/**</exclude>
+                                </excludes>
+                                <includes>
+                                    <include>src/**</include>
+                                </includes>
+                            </licenseSet>
+                        </licenseSets>
+
                         <mapping>
                             <java>SLASHSTAR_STYLE</java>
                             <g>SLASHSTAR_STYLE</g>
@@ -829,41 +865,11 @@
                         <properties>
                             <inceptionYear>${project.inceptionYear}</inceptionYear>
                         </properties>
-                        <headerSections>
-                            <headerSection>
-                                <key>COPYRIGHT_SECTION</key>
-                                <defaultValue>${air.license.default-value}</defaultValue>
-                                <ensureMatch>${air.license.ensure-match}</ensureMatch>
-                                <multiLineMatch>false</multiLineMatch>
-                            </headerSection>
-                        </headerSections>
+
                         <strictCheck>true</strictCheck>
                         <aggregate>true</aggregate>
                         <useDefaultExcludes>true</useDefaultExcludes>
                         <encoding>${project.build.sourceEncoding}</encoding>
-                        <excludes>
-                            <exclude>.*/**</exclude>
-                            <exclude>**/*.md</exclude>
-                            <exclude>**/*.sh</exclude>
-                            <exclude>**/*.txt</exclude>
-                            <exclude>**/*.thrift</exclude>
-                            <exclude>**/*.sql</exclude>
-                            <exclude>**/*.releaseBackup</exclude>
-                            <exclude>**/*.st</exclude>
-                            <exclude>**/*.raw</exclude>
-                            <exclude>**/*.ser</exclude>
-                            <exclude>**/*.html</exclude>
-                            <exclude>**/*.rst</exclude>
-                            <exclude>**/*.xml</exclude>
-                            <exclude>**/*.csv</exclude>
-                            <exclude>**/*.tsv</exclude>
-                            <exclude>**/*.properties</exclude>
-                            <exclude>**/src/license/**</exclude>
-                            <exclude>**/src/*/resources/**</exclude>
-                        </excludes>
-                        <includes>
-                            <include>src/**</include>
-                        </includes>
                     </configuration>
                     <executions>
                         <execution>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -275,7 +275,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.2.0</version>
                 </plugin>
 
                 <plugin>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -212,7 +212,7 @@
         <dep.logback.version>1.4.6</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>
         <dep.opentelemetry.version>1.26.0</dep.opentelemetry.version>
-        <dep.opentelemetry-instrumentation.version>1.24.0</dep.opentelemetry-instrumentation.version>
+        <dep.opentelemetry-instrumentation.version>1.25.1</dep.opentelemetry-instrumentation.version>
         <dep.slf4j.version>2.0.7</dep.slf4j.version>
         <dep.slice.version>0.45</dep.slice.version>
         <dep.spotbugs-annotations.version>4.7.3</dep.spotbugs-annotations.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -293,7 +293,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.codehaus.mojo</groupId>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -482,7 +482,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <!-- must be true for jar-with-dependencies builds -->
                         <appendAssemblyId>true</appendAssemblyId>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -885,7 +885,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.9</version>
+                    <version>0.8.10</version>
                     <executions>
                         <execution>
                             <id>default</id>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -623,7 +623,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -208,7 +208,7 @@
         <dep.jmxutils.version>1.23</dep.jmxutils.version>
         <dep.joda.version>2.12.5</dep.joda.version>
         <dep.junit.version>5.9.3</dep.junit.version>
-        <dep.kotlin.version>1.8.20</dep.kotlin.version>
+        <dep.kotlin.version>1.8.21</dep.kotlin.version>
         <dep.logback.version>1.4.6</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>
         <dep.opentelemetry.version>1.25.0</dep.opentelemetry.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -200,7 +200,7 @@
         <dep.assertj-core.version>3.24.2</dep.assertj-core.version>
         <dep.bval.version>2.0.6</dep.bval.version>
         <dep.guava.version>31.1-jre</dep.guava.version>
-        <dep.guice.version>5.1.0</dep.guice.version>
+        <dep.guice.version>6.0.0</dep.guice.version>
         <dep.jackson.version>2.15.0</dep.jackson.version>
         <dep.javax-inject.version>1</dep.javax-inject.version>
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -473,7 +473,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -928,7 +928,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.2.2</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -933,7 +933,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>10.9.3</version>
+                            <version>10.11.0</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -602,9 +602,9 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.5</version>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
+                    <version>5.0.0</version>
                     <configuration>
                         <!-- Include only properties used above to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
                         <includeOnlyProperties>
@@ -1031,8 +1031,8 @@
             </plugin>
 
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>default</id>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -982,7 +982,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.12.1</version>
                 </plugin>
 
                 <plugin>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -571,7 +571,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                     <executions>
                         <execution>
                             <id>attach-tests</id>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -211,7 +211,7 @@
         <dep.kotlin.version>1.8.21</dep.kotlin.version>
         <dep.logback.version>1.4.6</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>
-        <dep.opentelemetry.version>1.25.0</dep.opentelemetry.version>
+        <dep.opentelemetry.version>1.26.0</dep.opentelemetry.version>
         <dep.opentelemetry-instrumentation.version>1.24.0</dep.opentelemetry-instrumentation.version>
         <dep.slf4j.version>2.0.7</dep.slf4j.version>
         <dep.slice.version>0.45</dep.slice.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -207,7 +207,7 @@
         <dep.jmh.version>1.36</dep.jmh.version>
         <dep.jmxutils.version>1.23</dep.jmxutils.version>
         <dep.joda.version>2.12.5</dep.joda.version>
-        <dep.junit.version>5.9.2</dep.junit.version>
+        <dep.junit.version>5.9.3</dep.junit.version>
         <dep.kotlin.version>1.8.20</dep.kotlin.version>
         <dep.logback.version>1.4.6</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -209,7 +209,7 @@
         <dep.joda.version>2.12.5</dep.joda.version>
         <dep.junit.version>5.9.3</dep.junit.version>
         <dep.kotlin.version>1.8.21</dep.kotlin.version>
-        <dep.logback.version>1.4.6</dep.logback.version>
+        <dep.logback.version>1.4.7</dep.logback.version>
         <dep.modernizer.version>2.6.0</dep.modernizer.version>
         <dep.opentelemetry.version>1.26.0</dep.opentelemetry.version>
         <dep.opentelemetry-instrumentation.version>1.25.1</dep.opentelemetry-instrumentation.version>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -548,7 +548,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <quiet>true</quiet>
                         <source>${project.build.targetJdk}</source>


### PR DESCRIPTION
This PR updates bunch of dependencies and plugins to the newest versions.

Tested locally in Trino master - there are no API changes that require code changes. Plugins doesn't need configuration updates. Updated checkstyle is not introducing new violations.

I've left maven-release and gpg plugins outdated as I don't have means to test them properly.

Trino builds with just:

```
<parent>
    <groupId>io.airlift</groupId>
    <artifactId>airbase</artifactId>
    <version>139-SNAPSHOT</version>
</parent>
```