### PR TITLE
Fix running timezone-sensitive tests in IntelliJ IDEA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Airbase 140
+
+* Pass `user.timezone` in tests as a system property, not as a JVM argument
+  - It restores the ability to run some timezone-sensitive tests
+    from within IntelliJ IDEA
+
 Airbase 139
 
 * Replace checkstyle illegal imports with `RestrictImports` enforcer rules

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -498,6 +498,7 @@
                     <configuration>
                         <systemPropertyVariables>
                             <sun.jnu.encoding>${project.build.sourceEncoding}</sun.jnu.encoding>
+                            <user.timezone>${air.test.timezone}</user.timezone>
                             <java.awt.headless>true</java.awt.headless>
                             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS.%1$tL%1$tz %4$s %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
                         </systemPropertyVariables>
@@ -510,9 +511,7 @@
                         <argLine>
                             @{argLine}
 
-                            <!-- Pass the following three directly to the JVM,
-                                 because systemPropertyVariables are not passed correctly by Maven -->
-                            -Duser.timezone=${air.test.timezone}
+                            <!-- Pass the following properties directly to the JVM, because they are not passed correctly by Surefire: -->
                             -Duser.language=${air.test.language}
                             -Duser.region=${air.test.region}
 


### PR DESCRIPTION
Some time ago, some properties were moved to `argLine` because Surefire incorrectly passes the `user.language` and `user.region` system properties to the tests. At that time, the `user.timezone` also got along for the ride, but it turns out, that that latter property *is* passed correctly. So while it works for Maven and Surefire, moving it into `argLine` causes IntelliJ IDEA to not pick it up, which in turn means that some tests are not working properly when executed inside the IDE. We can move it safely back, as it improves quality of life.

This reverts parts of commit d4630aa6547a64c7112f2bf133138d7d83b6d1a8.