### PR TITLE
Update extra-enforcer-rules to 1.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Airbase 140
   - duplicate-finder-maven-plugin 2.0.1 (from 1.5.1)
   - maven-scm-plugin 2.0.1 (from 2.0.0)
   - git-commit-id-maven-plugin 6.0.0 (from 5.0.0)
+  - extra-enforcer-rules 1.7.0 (from 1.6.2)
 
 Airbase 139
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -299,7 +299,7 @@
                         <dependency>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>extra-enforcer-rules</artifactId>
-                            <version>1.6.2</version>
+                            <version>1.7.0</version>
                         </dependency>
                         <dependency>
                             <groupId>de.skuzzle.enforcer</groupId>


### PR DESCRIPTION
This version recognized JDK 21 classes correctly (previous one fails on JDK 21 with target 21)