### PR TITLE
Update jackson to 2.15.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Airbase 143
 
 * Relax restricted imports for Jersey
+* Dependency updates:
+  - jackson 2.15.2 (from 2.15.0)
 
 Airbase 142
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -201,7 +201,7 @@
         <dep.bval.version>2.0.6</dep.bval.version>
         <dep.guava.version>32.0.0-jre</dep.guava.version>
         <dep.guice.version>7.0.0</dep.guice.version>
-        <dep.jackson.version>2.15.0</dep.jackson.version>
+        <dep.jackson.version>2.15.2</dep.jackson.version>
         <dep.jmh.version>1.36</dep.jmh.version>
         <dep.jmxutils.version>1.23</dep.jmxutils.version>
         <dep.joda.version>2.12.5</dep.joda.version>


### PR DESCRIPTION
Bumps only patch versions, might be required by some libraries that already use latest patch. 

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15