### PR TITLE
Update maven-shade-plugin to 3.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Airbase 143
   - jackson 2.15.2 (from 2.15.0)
 * Plugin updates:
   - maven-gpg-plugin 3.1.0 (from 1.4.0)
+  - maven-shade-plugin 3.5.0 (from 3.4.1)
 
 Airbase 142
 

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -995,7 +995,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
This release, among other things, natively depends on ASM 9.5 with support for new opcodes in Java 21, but we'll keep the ASM version override in case we need a blanket ASM upgrade in the future.