### PR TITLE
Suppress maven warning on platform dependant build

### DIFF
--- a/airbase-policy/pom.xml
+++ b/airbase-policy/pom.xml
@@ -11,4 +11,8 @@
     <artifactId>airbase-policy</artifactId>
 
     <description>Policy files for Airbase</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>


### PR DESCRIPTION
Removes warning:

```
[INFO] --- resources:3.3.1:testResources (default-testResources) @ airbase-policy ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /Users/mateuszgajewski/Projects/src/github.com/airlift/airbase/airbase-policy/src/test/resources
```