### PR TITLE
Improve developers section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
     <developers>
         <!-- see git log -->
         <developer>
-            <name>Airlift</name>
+            <name>Numerous contributors, see scm log</name>
+            <url>${project.scm.url}</url>
         </developer>
     </developers>
 


### PR DESCRIPTION
With the current setup any inheriting project has to override developers .. otherwise they get
the following in the effective pom: 

```
<developers>
    <!-- see git log -->
    <developer>
        <name>Airlift</name>
    </developer>
</developers>
```

Which is wrong. This is currently the case in Trino for example.

The new setup pulls the scm url into place and results in a correct URL to the github or whatever repo and has a generic sentence instead of referencing airlift. Here is the effective pom for this project itself:

```
    <developers>
      <developer>
        <name>Numerous contributors, see scm log</name>
        <url>https://github.com/airlift/airbase</url>
      </developer>
    </developers>
```

It uses the property so for example in Trino we would get this:

```
    <developers>
      <developer>
        <name>Numerous contributors, see scm log</name>
        <url>https://github.com/trinodb/trino</url>
      </developer>
    </developers>
```

and in the Trino Gateway:

```
    <developers>
      <developer>
        <name>Numerous contributors, see scm log</name>
        <url>https://github.com/trinodb/trino-gateway</url>
      </developer>
    </developers>
```

Note that the property `project.scm.url` is filled in most cases since it is needed for Central deployment and release plugin usage.

Discovered during work on https://github.com/trinodb/trino-gateway/pull/29 and requested by @dain 

FYI @electrum @martint 