### PR TITLE
Downgrade logback to 1.4.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@ Airbase 147
 
 * Automatically sort and verify POM files
 
+* Dependency downgrades:
+  - logback 1.4.8 (from 1.4.11)
+
 Airbase 146
 
 * Plugin updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -179,7 +179,7 @@
         <dep.joda.version>2.12.5</dep.joda.version>
         <dep.junit.version>5.10.0</dep.junit.version>
         <dep.kotlin.version>1.9.0</dep.kotlin.version>
-        <dep.logback.version>1.4.11</dep.logback.version>
+        <dep.logback.version>1.4.8</dep.logback.version>
         <dep.modernizer.version>2.7.0</dep.modernizer.version>
         <dep.opentelemetry.version>1.30.1</dep.opentelemetry.version>
         <dep.opentelemetry-instrumentation.version>1.30.0</dep.opentelemetry-instrumentation.version>


### PR DESCRIPTION
There is a regression in logback 1.4.9 which causes Trino tests to fail due to timeouts. The root cause is still to be investigated.

Related: https://github.com/trinodb/trino/pull/19194
Trino logback update test: https://github.com/trinodb/trino/pull/19207