### PR TITLE
Bump git-commit-id-maven-plugin to 7.0.0 to fix git worktree issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Airbase 149
+
+* Plugin updates:
+  - git-commit-id-maven-plugin 7.0.0 (from 6.0.0)
+
 Airbase 148
 
 * Import AssertJ bom

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -958,7 +958,7 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>6.0.0</version>
+                    <version>7.0.0</version>
                     <configuration>
                         <!-- Include only properties used above to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
                         <includeOnlyProperties>


### PR DESCRIPTION
Bump `git-commit-id-maven-plugin` to [version 7.0.0](https://github.com/git-commit-id/git-commit-id-maven-plugin/releases/tag/v7.0.0), which most notably fixes an issue where the plugin doesn't work properly in Git worktrees. See https://github.com/trinodb/trino/issues/18027 for more details on the issue. This will allow consumers to get rid of workarounds like the one introduced to Trino in https://github.com/trinodb/trino/pull/18046