### PR TITLE
Forbid code that would reformat poorly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1162,4 +1162,3 @@ Airbase 2
 Airbase 1
 
 * Initial release
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 Airbase 149
 * Remove bval dependency
+* Checkstyle updates:
+  - Disallow single-line non-empty lambda and method body code blocks.
 * Plugin updates:
   - git-commit-id-maven-plugin 7.0.0 (from 6.0.0)
   - spotbugs-maven-plugins 4.8.1.0 (from 4.7.3.6)

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -256,6 +256,22 @@
             <property name="ignoreComments" value="true" />
         </module>
 
+        <module name="RegexpSinglelineJava">
+            <!-- when "{" denotes conditional/loop statement body, IntelliJ would reformat adding line break -->
+            <!-- when "{" denotes method/lambda body, and closing brace is on the same line, IntelliJ would remove whitespace before throw, violating "{" whitespace expectations-->
+            <property name="format" value="\{\s*+throw\b" />
+            <property name="message" value="No new line before throw" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <!-- when "}" denotes end of conditional/loop statement body, IntelliJ would reformat adding line break -->
+            <!-- when "}" denotes end of method/lambda body and opening brace is on the same line, IntelliJ would remove whitespace before the brace, violating "}" whitespace expectations-->
+            <property name="format" value=";\s*+\}(?!&quot;)" />
+            <property name="message" value="No new line before closing brace" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
         <!-- javadoc -->
         <module name="RequireEmptyLineBeforeBlockTagGroup" />
         <module name="NonEmptyAtclauseDescription" />


### PR DESCRIPTION
Current checkstyle rules somehow allow things like

    void run() { throw new UnsupportedOperationException(); }

    Runnable r = () -> { throw new RuntimeException(); }

    Runnable asRunnable()
    { a_field++; }

    void update()
    { throw new RuntimeException(); }

however, when such code is then auto-formatted by IntelliJ with Airbase codestyle, some whitespace is removed, resulting in a code that violates checkstyle rules. This state is undesired: sometimes a person working on a class file may need to undo auto-formatting so pass checkstyle checks.

The new rules aim to reduce such situation by recognizing some common would-format-incorrectly patterns.