### PR TITLE
Forbid no/abundant whitespace before array initializer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 155
+* Checkstyle updates:
+  - Require exactly one space between array type and array initializer.
+
 Airbase 154
 * Fix javadoc building when `air.compiler.enable-preview` is set
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1220,4 +1220,3 @@ Airbase 2
 Airbase 1
 
 * Initial release
-

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -256,6 +256,14 @@
             <property name="ignoreComments" value="true" />
         </module>
 
+        <module name="RegexpSinglelineJava">
+            <!-- Forbid "new Type[]{",  IntelliJ would reformat adding a space -->
+            <!-- Forbid "new Type[]  {",  IntelliJ would reformat removing a space -->
+            <property name="format" value="new\s++\w++(&lt;\?&gt;)?(\[\])++(\s{2,})?\{" />
+            <property name="message" value="Incorrect whitespace before array initializer" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
         <!-- javadoc -->
         <module name="RequireEmptyLineBeforeBlockTagGroup" />
         <module name="NonEmptyAtclauseDescription" />


### PR DESCRIPTION
Forbid these

    new int[]{...

    new int[]    {....


Extracted from https://github.com/airlift/airbase/pull/389