### PR TITLE
Downgrade modernizer to 2.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Airbase 152
+* Dependency downgrades:
+  - modernizer-maven-annotations 2.7.0 (from 2.8.0)
+
 Airbase 151
 * Plugin updates:
   - maven-shade-plugin 3.5.2 (from 3.5.1)

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -179,7 +179,7 @@
         <dep.junit.version>5.10.2</dep.junit.version>
         <dep.kotlin.version>1.9.22</dep.kotlin.version>
         <dep.logback.version>1.5.1</dep.logback.version>
-        <dep.modernizer.version>2.8.0</dep.modernizer.version>
+        <dep.modernizer.version>2.7.0</dep.modernizer.version>
         <dep.opentelemetry.version>1.35.0</dep.opentelemetry.version>
         <dep.opentelemetry-instrumentation.version>2.1.0</dep.opentelemetry-instrumentation.version>
         <dep.slf4j.version>2.0.12</dep.slf4j.version>


### PR DESCRIPTION
2.8.0 requires maven 3.9.6 and doesn't work with mvnd in the process.