### PR TITLE
Update extra-enforcer-rules to 1.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Airbase 152
   - ASM 9.6 (from 9.5)
 * Plugin updates:
   - git-commit-id-maven-plugin 8.0.0 (from 7.0.0) 
+  - extra-enforcer-rules 1.8.0 (from 1.7.0)
 
 Airbase 151
 * Plugin updates:

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -711,7 +711,7 @@
                         <dependency>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>extra-enforcer-rules</artifactId>
-                            <version>1.7.0</version>
+                            <version>1.8.0</version>
                         </dependency>
                     </dependencies>
                     <executions>


### PR DESCRIPTION
This brings compatibility with JDK 22-23 class formats.