### PR TITLE
Disallow class-level warning suppression 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Airbase 157
 * Checkstyle updates:
+ - Disallow class-level warning suppression
  - Require empty line before record definition
 
 Airbase 156

--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -105,6 +105,21 @@
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder" />
 
+        <!-- Disallow class-level warning suppression -->
+        <module name="SuppressWarnings">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF" />
+            <property name="format" value="(?sx)
+                (?! ^ (
+                    ClassMayBeInterface |
+                    EmptyClass |
+                    EnumeratedConstantNamingConvention |
+                    ExceptionClassNameDoesntEndWithException |
+                    FieldMayBeFinal |
+                    MarkerInterface |
+                    MethodMayBeStatic ) $ )
+                .*" />
+        </module>
+
         <module name="SuppressionXpathSingleFilter">
             <property name="checks" value="RedundantModifier"/>
             <property name="query" value="//(CLASS_DEF|RECORD_DEF)/OBJBLOCK/*/MODIFIERS/*"/>


### PR DESCRIPTION
`@SuppressWarnings` should be applied to narrowest scope possible.
