### PR TITLE
Remove `InterfaceIsType` checkstyle module

### DIFF
--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -168,7 +168,6 @@
         <module name="MutableException" />
         <module name="EqualsHashCode" />
         <module name="InnerAssignment" />
-        <module name="InterfaceIsType" />
         <module name="HideUtilityClassConstructor" />
         <module name="ExplicitInitialization" />
         <module name="OneTopLevelClass" />


### PR DESCRIPTION
This check prevents a modern Java idiom (and likely future idioms). E.g.

```
public sealed interface Choice
{
    record GoodChoice(...)
        implements Choice
    {
    }

    record BadChoice(...)
        implements Choice
    {
    }
}
```

The previous purpose of `InterfaceIsType` is arguably out of date anyway. It's better to use an interface for utility containers, etc.