### PR TITLE
Require JDK 17

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -151,7 +151,7 @@
         <air.maven.version>3.9.8</air.maven.version>
 
         <!-- minimum Java version to build -->
-        <air.java.version>11</air.java.version>
+        <air.java.version>17</air.java.version>
 
         <!-- In Multimodule builds, override this to point at the parent directory for e.g. the license resources. -->
         <!-- See http://stackoverflow.com/questions/1012402/maven2-property-that-indicates-the-parent-directory    -->


### PR DESCRIPTION
Some of the maven plugins (like error_prone) have moved to JDK 17.

<!-- Thank you for submitting pull request to Airbase -->

# Airbase contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
