### PR TITLE
Ignore module-info.java in checkstyle

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -1344,6 +1344,7 @@
                                 <failOnViolation>${air.check.fail-checkstyle}</failOnViolation>
                                 <includeTestSourceDirectory>true</includeTestSourceDirectory>
                                 <configLocation>${air.checkstyle.config-file}</configLocation>
+                                <excludes>**/module-info.java</excludes>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Checkstyle doesn't yet support them: https://github.com/checkstyle/checkstyle/issues/8240
