### PR TITLE
Suppress indentation check inside switch expressions

### DIFF
--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -153,6 +153,11 @@
         <module name="NoWhitespaceAfter" />
         <module name="NoWhitespaceBefore" />
         <module name="SingleSpaceSeparator" />
+
+        <module name="SuppressionXpathSingleFilter">
+            <property name="checks" value="Indentation" />
+            <property name="query" value="//LITERAL_SWITCH//*" />
+        </module>
         <module name="Indentation">
             <property name="throwsIndent" value="8" />
             <property name="lineWrappingIndentation" value="8" />


### PR DESCRIPTION
The check currently does not handle aligned wrapped cases or nested switch expressions.