### PR TITLE
Allow arbitrary indentation in the return clause

### DIFF
--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -109,6 +109,7 @@
             <property name="checks" value="RedundantModifier"/>
             <property name="query" value="//(CLASS_DEF|RECORD_DEF)/OBJBLOCK/*/MODIFIERS/*"/>
         </module>
+
         <module name="RedundantModifier" />
 
         <module name="EmptyBlock">
@@ -158,6 +159,12 @@
             <property name="checks" value="Indentation" />
             <property name="query" value="//LITERAL_SWITCH//*" />
         </module>
+
+        <module name="SuppressionXpathSingleFilter">
+            <property name="checks" value="Indentation" />
+            <property name="query" value="//LITERAL_RETURN//*" />
+        </module>
+
         <module name="Indentation">
             <property name="throwsIndent" value="8" />
             <property name="lineWrappingIndentation" value="8" />


### PR DESCRIPTION
This allows wrapping next line and aligning it with after return itself

<!-- Thank you for submitting pull request to Airbase -->

# Airbase contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
