### PR TITLE
Set resources plugin propertiesEncoding to ISO-8859-1

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -949,6 +949,7 @@
                     <version>${dep.plugin.resources.version}</version>
                     <configuration>
                         <encoding>${project.build.sourceEncoding}</encoding>
+                        <propertiesEncoding>ISO-8859-1</propertiesEncoding>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
This is the encoding expected by the Properties.load

<!-- Thank you for submitting pull request to Airbase -->

# Airbase contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
