### PR TITLE
Allow flexible constructor bodies

### DIFF
--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -103,6 +103,18 @@
     <module name="SuppressWarningsFilter" />
 
     <module name="TreeWalker">
+        <!--
+          Suppress Checkstyle Java code parse errors.
+          TODO (https://github.com/checkstyle/checkstyle/issues/17052) remove suppression when checkstyle supports flexible constructor bodies (JEP 513)
+          -->
+        <property name="skipFileOnJavaParseException" value="true" />
+        <!--
+          When Checkstyle encounters a Java parse error that is suppressed with skipFileOnJavaParseException=true,
+          it logs it on ERROR by default, which leads to maven build failure.
+          Note however that 'warning' works same as 'ignore' — unfortunately no warning appears on console.
+          -->
+        <property name="javaParseExceptionSeverity" value="warning" />
+
         <module name="SuppressWarningsHolder" />
 
         <module name="SuppressionXpathSingleFilter">


### PR DESCRIPTION
Java 25 adds ability to place statements within constructor before call to `super()`. Checkstyle does not support this yet, so it's configured not to fail the build on these.
