### PR TITLE
Disallow use of awaitility library

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -858,6 +858,14 @@
                                     <bannedImport>org.assertj.core.api.AssertionsForInterfaceTypes.*</bannedImport>
                                 </bannedImports>
                             </RestrictImports>
+                            <RestrictImports>
+                                <!-- See https://github.com/trinodb/trino/pull/28055 description for detailed problem analysis -->
+                                <reason>The awaitility library mutates JVM state and affects isolation between JUnit tests (https://github.com/awaitility/awaitility/issues/120#issuecomment-420977109). Its use is discouraged.</reason>
+                                <bannedImports>
+                                    <bannedImport>org.awaitility.**</bannedImport>
+                                    <bannedImport>**.org.awaitility.**</bannedImport>
+                                </bannedImports>
+                            </RestrictImports>
                             <requireProfileIdsExist />
                             <requirePropertyDiverges>
                                 <property>project.description</property>


### PR DESCRIPTION
The awaitility library mutates JVM state and affects isolation between JUnit tests. Its use is discouraged.  For example in Trino it caused `TestNodeStateManager` test to become flaky by intercepting exceptions from threads spawned by a different test. The two tests did not share any common executor or anything.  Likely the reason for this is the fact the library installs a global exception handler.

While this awaitility's behavior is configurable, it's also the default. It is also not clear whether this is the only problem. Discourage use of the library.

- follows https://github.com/trinodb/trino/issues/25705#issuecomment-3823539429