### PR TITLE
Remove obsolete text block suppression

### DIFF
--- a/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
+++ b/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml
@@ -3,11 +3,6 @@
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 <module name="Checker">
-    <module name="SuppressWithPlainTextCommentFilter">
-        <property name="offCommentFormat" value='"""'/>
-        <property name="onCommentFormat" value='"""'/>
-    </module>
-
     <module name="SuppressWarningsFilter" />
 
     <module name="TreeWalker">


### PR DESCRIPTION
Remove an obsolete Checkstyle text-block suppression now that the rules it protected are no longer part of Airbase.