### PR TITLE
Revert "Bump com.fasterxml.jackson:jackson-bom from 2.21.4 to 2.22.0"

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -212,7 +212,7 @@
         <dep.guava.version>33.6.0-jre</dep.guava.version>
         <dep.guice.version>7.0.0</dep.guice.version>
         <dep.hibernate-validator.version>9.1.0.Final</dep.hibernate-validator.version>
-        <dep.jackson.version>2.22.0</dep.jackson.version>
+        <dep.jackson.version>2.21.4</dep.jackson.version>
         <dep.jackson3.version>3.1.4</dep.jackson3.version>
         <dep.jakarta.annotation-api.version>3.0.0</dep.jakarta.annotation-api.version>
         <dep.jakarta.inject-api.version>2.0.1</dep.jakarta.inject-api.version>


### PR DESCRIPTION
Reverts airlift/airbase#1230

2.22.0 is incorrectly released and lacks jackson-core in the oss central