### PR TITLE
Upgrade njord to fix mvnd crashes

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -184,7 +184,7 @@
         <dep.plugin.javadoc.version>3.12.0</dep.plugin.javadoc.version>
         <dep.plugin.license.version>5.0.0</dep.plugin.license.version>
         <dep.plugin.modernizer.version>3.4.0</dep.plugin.modernizer.version>
-        <dep.plugin.njord.version>0.9.7</dep.plugin.njord.version>
+        <dep.plugin.njord.version>0.9.8</dep.plugin.njord.version>
         <dep.plugin.pmd-runtime.version>7.25.0</dep.plugin.pmd-runtime.version>
         <dep.plugin.pmd.version>3.28.0</dep.plugin.pmd.version>
         <dep.plugin.release.version>3.3.1</dep.plugin.release.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </modules>
 
     <properties>
-        <dep.plugin.njord.version>0.9.7</dep.plugin.njord.version>
+        <dep.plugin.njord.version>0.9.8</dep.plugin.njord.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Builds involving airbase would sometimes crash `mvnd install` if the daemon is used to build different projects, using different njord version. This is hopefully fixed upstream in njord version this upgrades to:

- https://github.com/maveniverse/njord/pull/308