### PR TITLE
Remove dependency scope plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,6 @@ The following switches exist:
     <td><tt>air.check.fail-duplicate-finder</tt></td>
   </tr>
   <tr>
-    <td>Basic</td>
-    <td>Maven Dependency scope</td>
-    <td><tt>air.check.skip-dependency-scope</tt></td>
-    <td><tt>air.check.fail-dependency-scope</tt></td>
-  </tr>
-  <tr>
     <td>Extended</td>
     <td>SpotBugs</td>
     <td><tt>air.check.skip-spotbugs</tt></td>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -119,7 +119,6 @@
         <air.check.skip-enforcer>${air.check.skip-basic}</air.check.skip-enforcer>
         <air.check.skip-dependency>${air.check.skip-basic}</air.check.skip-dependency>
         <air.check.skip-duplicate-finder>${air.check.skip-basic}</air.check.skip-duplicate-finder>
-        <air.check.skip-dependency-scope>${air.check.skip-basic}</air.check.skip-dependency-scope>
 
         <!-- extended checks -->
         <air.check.skip-spotbugs>${air.check.skip-extended}</air.check.skip-spotbugs>
@@ -139,7 +138,6 @@
         <air.check.fail-enforcer>${air.check.fail-basic}</air.check.fail-enforcer>
         <air.check.fail-dependency>${air.check.fail-basic}</air.check.fail-dependency>
         <air.check.fail-duplicate-finder>${air.check.fail-basic}</air.check.fail-duplicate-finder>
-        <air.check.fail-dependency-scope>${air.check.fail-basic}</air.check.fail-dependency-scope>
 
         <!-- extended checks -->
         <air.check.fail-spotbugs>${air.check.fail-extended}</air.check.fail-spotbugs>
@@ -172,7 +170,6 @@
         <dep.plugin.commit-id.version>10.0.0</dep.plugin.commit-id.version>
         <dep.plugin.compiler.version>3.15.0</dep.plugin.compiler.version>
         <dep.plugin.dependency.version>3.11.0</dep.plugin.dependency.version>
-        <dep.plugin.dependency-scope.version>1.0.3</dep.plugin.dependency-scope.version>
         <dep.plugin.deploy.version>3.1.4</dep.plugin.deploy.version>
         <dep.plugin.duplicate-finder.version>2.0.1</dep.plugin.duplicate-finder.version>
         <dep.plugin.enforcer.version>3.6.3</dep.plugin.enforcer.version>
@@ -1228,23 +1225,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.basepom.maven</groupId>
-                    <artifactId>dependency-scope-maven-plugin</artifactId>
-                    <version>${dep.plugin.dependency-scope.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <skip>${air.check.skip-dependency-scope}</skip>
-                                <fail>${air.check.fail-dependency-scope}</fail>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>${dep.plugin.spotbugs.version}</version>
@@ -1693,23 +1673,6 @@
                     <plugin>
                         <groupId>com.github.ekryd.sortpom</groupId>
                         <artifactId>sortpom-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>dependency-scope-check</id>
-            <activation>
-                <property>
-                    <name>air.check.skip-all</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.basepom.maven</groupId>
-                        <artifactId>dependency-scope-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Removes the dependency-scope checker from the base POM now that the runtime classpath bug it worked around has been fixed in the assembly plugin and Provisio.

This also removes the now-unused checker properties from the README.
