### PR TITLE
Add OpenTelemetry API incubator

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -492,6 +492,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api-incubator</artifactId>
+                <version>${dep.opentelemetry-alpha.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.opentelemetry.semconv</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
                 <version>${dep.opentelemetry-semconv.version}</version>


### PR DESCRIPTION
Adds the OpenTelemetry incubator API dependency so downstream projects can use its incubating APIs.