### PR TITLE
Revert org.apache.maven.plugins:maven-surefire-plugin to 3.6.0

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -193,7 +193,7 @@
         <dep.plugin.sortpom.version>4.0.0</dep.plugin.sortpom.version>
         <dep.plugin.source.version>3.4.0</dep.plugin.source.version>
         <dep.plugin.spotbugs.version>4.10.4.1</dep.plugin.spotbugs.version>
-        <dep.plugin.surefire.version>3.6.0</dep.plugin.surefire.version>
+        <dep.plugin.surefire.version>3.5.6</dep.plugin.surefire.version>
         <dep.plugin.wrapper.version>3.3.4</dep.plugin.wrapper.version>
 
         <!-- Packaging for the tarball deployment -->


### PR DESCRIPTION
This reverts commit 48f487509a739eb055f25923faa6d32f7a17d78e due to https://github.com/apache/maven-surefire/issues/3460

<!-- Thank you for submitting pull request to Airbase -->

# Airbase contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
